### PR TITLE
Use local tmp directory and enhance readme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nitter
 *.db
 /tests/__pycache__
 /tests/geckodriver.log
+/tmp

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ WantedBy=multi-user.target
 ```
 
 Then enable and start
-`systemctl enable --now nitter.service && systemctl start nitter.service`
+`systemctl enable --now nitter.service`
 
 ## Todo (roughly in this order)
 

--- a/README.md
+++ b/README.md
@@ -14,14 +14,49 @@ Inspired by the [invidio.us](https://github.com/omarroth/invidious) project.
 ## Installation
 
 ```bash
-git clone https://github.com/zedeus/nitter
-cd nitter
-nimble build
+# useradd -m nitter
+# su nitter
+$ curl https://nim-lang.org/choosenim/init.sh -sSf | sh
+$ git clone https://github.com/zedeus/nitter
+$ cd nitter
+$ nimble build
+$ mkdir ./tmp
 ```
 
-To run, `./nitter`. It's currently not possible to change any settings or things
+To run nitter, execute `./nitter`. It's currently not possible to change any settings or things
 like the title, this will change as the project matures a bit. For now the focus
 is on implementing missing features.
+
+You should put nitter behind a reverse proxy with e.g. nginx or apache.
+
+It is also possibele to run nitter via systemd:
+
+```bash
+[Unit]
+Description=Nitter (An alternative Twitter front-end)
+After=syslog.target
+After=network.target
+
+[Service]
+Type=simple
+
+# set user and group
+User=nitter
+Group=nitter
+
+# configure location
+WorkingDirectory=/home/nitter/nitter
+ExecStart=/home/nitter/nitter/nitter
+
+Restart=always
+RestartSec=15
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Than enable and start
+`systemctl enable nitter.service && systemctl start nitter.service`
 
 ## Todo (roughly in this order)
 

--- a/README.md
+++ b/README.md
@@ -13,13 +13,15 @@ Inspired by the [invidio.us](https://github.com/omarroth/invidious) project.
 
 ## Installation
 
+You need to install nimble on your system: https://nim-lang.org/install.html
+It is possible to install nimble system wide or in the user directory you create below.
+
 ```bash
 # useradd -m nitter
 # su nitter
-$ curl https://nim-lang.org/choosenim/init.sh -sSf | sh
 $ git clone https://github.com/zedeus/nitter
 $ cd nitter
-$ nimble build
+$ nimble build -d:release
 $ mkdir ./tmp
 ```
 
@@ -29,7 +31,7 @@ is on implementing missing features.
 
 You should put nitter behind a reverse proxy with e.g. nginx or apache.
 
-It is also possibele to run nitter via systemd:
+It is also possible to run nitter via systemd:
 
 ```bash
 [Unit]
@@ -55,8 +57,8 @@ RestartSec=15
 WantedBy=multi-user.target
 ```
 
-Than enable and start
-`systemctl enable nitter.service && systemctl start nitter.service`
+Then enable and start
+`systemctl enable --now nitter.service && systemctl start nitter.service`
 
 ## Todo (roughly in this order)
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ Inspired by the [invidio.us](https://github.com/omarroth/invidious) project.
 
 ## Installation
 
-You need to install nimble on your system: https://nim-lang.org/install.html
-It is possible to install nimble system wide or in the user directory you create below.
+You need to install nim on your system: https://nim-lang.org/install.html
+It is possible to install nim system wide or in the user directory you create below.
 
 ```bash
 # useradd -m nitter

--- a/nitter.conf
+++ b/nitter.conf
@@ -5,5 +5,5 @@ title = "nitter"
 staticDir = "./public"
 
 [Cache]
-directory = "/tmp/niter"
+directory = "./tmp"
 profileMinutes = 10  # how long to cache profiles


### PR DESCRIPTION
Nitter should not use global tmp for more privacy and security. Also nitter should run under its own user.