### PR TITLE
add debian/ubuntu package for libsass to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,9 @@ Twitter account.
 
 ## Installation
 
-To compile Nitter you need a Nim installation, see here for details: https://nim-lang.org/install.html
+To compile Nitter you need a Nim installation, see [nim-lang.org](https://nim-lang.org/install.html) for details. It is possible to install it system-wide or in the user directory you create below.
 
-You also need to install `libsass` to compile the scss files.
-It is possible to install Nim system-wide or in the user directory you create below.
+You also need to install `libsass` to compile the scss files. In Ubuntu and Debian, you can install `libsass-dev`.
 
 ```bash
 # useradd -m nitter

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Twitter account.
 
 To compile Nitter you need a Nim installation, see [nim-lang.org](https://nim-lang.org/install.html) for details. It is possible to install it system-wide or in the user directory you create below.
 
-You also need to install `libsass` to compile the scss files. In Ubuntu and Debian, you can install `libsass-dev`.
+You also need to install `libsass` to compile the scss files. On Ubuntu and Debian, you can use `libsass-dev`.
 
 ```bash
 # useradd -m nitter


### PR DESCRIPTION
I've gotten a few messages from people asking how to install nitter and they send me screenshots of the error `could not load: libsass.so`. I added the package name to the readme to clear up confusion.