### PR TITLE
fixing rss url on nav

### DIFF
--- a/src/routes/timeline.nim
+++ b/src/routes/timeline.nim
@@ -91,5 +91,6 @@ proc createTimelineRouter*(cfg: Config) =
         of "media": getMediaQuery(@"name")
         of "search": initQuery(params(request), name=(@"name"))
         else: Query()
+      if @"tab" == "": rss = "/" & @"name" & "/rss"
       if @"tab" == "search": rss &= "?" & genQueryUrl(query)
       respTimeline(await showTimeline(request, query, cfg, rss))


### PR DESCRIPTION
RSS url on navbar is invalid when @"tab" is an empty string.