### PR TITLE
Change ID types to int64

### DIFF
--- a/src/cache.nim
+++ b/src/cache.nim
@@ -63,7 +63,7 @@ proc cache*(video: var Video) =
       if video.videoId.len > 0:
         video.insert()
 
-proc getCachedVideo*(id: int): Option[Video] =
+proc getCachedVideo*(id: int64): Option[Video] =
   withDb:
     try:
       return some Video.getOne("videoId = ?", $id)

--- a/src/formatters.nim
+++ b/src/formatters.nim
@@ -49,7 +49,7 @@ proc getUserpic*(userpic: string; style=""): string =
 proc getUserpic*(profile: Profile; style=""): string =
   getUserPic(profile.userpic, style)
 
-proc getVideoEmbed*(cfg: Config; id: int): string =
+proc getVideoEmbed*(cfg: Config; id: int64): string =
   &"https://{cfg.hostname}/i/videos/{id}"
 
 proc pageTitle*(profile: Profile): string =

--- a/src/parser.nim
+++ b/src/parser.nim
@@ -72,7 +72,7 @@ proc parseTweetProfile*(profile: XmlNode): Profile =
 
 proc parseQuote*(quote: XmlNode): Quote =
   result = Quote(
-    id:    parseInt(quote.attr("data-item-id")),
+    id:    parseBiggestInt(quote.attr("data-item-id")),
     text:  getQuoteText(quote),
     reply: parseTweetReply(quote),
     hasThread: quote.select(".self-thread-context") != nil,
@@ -99,8 +99,8 @@ proc parseTweet*(node: XmlNode): Tweet =
     return Tweet()
 
   result = Tweet(
-    id:        parseInt(tweet.attr("data-item-id")),
-    threadId:  parseInt(tweet.attr("data-conversation-id")),
+    id:        parseBiggestInt(tweet.attr("data-item-id")),
+    threadId:  parseBiggestInt(tweet.attr("data-conversation-id")),
     text:      getTweetText(tweet),
     time:      getTimestamp(tweet),
     shortTime: getShortTime(tweet),
@@ -119,7 +119,7 @@ proc parseTweet*(node: XmlNode): Tweet =
   if by.len > 0:
     result.retweet = some Retweet(
       by: stripText(by),
-      id: parseInt(tweet.attr("data-retweet-id"))
+      id: parseBiggestInt(tweet.attr("data-retweet-id"))
     )
 
   let quote = tweet.select(".QuoteTweet-innerContainer")
@@ -196,7 +196,7 @@ proc parseTimeline*(node: XmlNode; after: string): Timeline =
     beginning: after.len == 0
   )
 
-proc parseVideo*(node: JsonNode; tweetId: int): Video =
+proc parseVideo*(node: JsonNode; tweetId: int64): Video =
   let
     track = node{"track"}
     cType = track["contentType"].to(string)

--- a/src/parserutils.nim
+++ b/src/parserutils.nim
@@ -82,7 +82,7 @@ proc getTweetText*(tweet: XmlNode): string =
 
 proc getTimestamp*(tweet: XmlNode): Time =
   let time = tweet.selectAttr(".js-short-timestamp", "data-time")
-  fromUnix(if time.len > 0: parseInt(time) else: 0)
+  fromUnix(if time.len > 0: parseBiggestInt(time) else: 0)
 
 proc getShortTime*(tweet: XmlNode): string =
   tweet.selectText(".js-short-timestamp")
@@ -270,9 +270,9 @@ proc getTweetCard*(tweet: Tweet; node: XmlNode) =
 
   tweet.card = some card
 
-proc getMoreReplies*(node: XmlNode): int =
+proc getMoreReplies*(node: XmlNode): int64 =
   let text = node.innerText().strip()
   try:
-    result = parseInt(text.split(" ")[0])
+    result = parseBiggestInt(text.split(" ")[0])
   except:
     result = -1

--- a/src/routes/embed.nim
+++ b/src/routes/embed.nim
@@ -11,6 +11,6 @@ export embed
 proc createEmbedRouter*(cfg: Config) =
   router embed:
     get "/i/videos/tweet/@id":
-      let tweet = Tweet(id: @"id".parseInt, video: some Video())
+      let tweet = Tweet(id: @"id".parseBiggestInt, video: some Video())
       await getVideo(tweet, getAgent(), "")
       resp renderVideoEmbed(cfg, tweet)

--- a/src/types.nim
+++ b/src/types.nim
@@ -115,7 +115,7 @@ type
     video*: Option[Video]
 
   Quote* = object
-    id*: int
+    id*: int64
     profile*: Profile
     text*: string
     reply*: seq[string]
@@ -128,7 +128,7 @@ type
 
   Retweet* = object
     by*: string
-    id*: int
+    id*: int64
 
   TweetStats* = object
     replies*: string
@@ -136,8 +136,8 @@ type
     likes*: string
 
   Tweet* = ref object
-    id*: int
-    threadId*: int
+    id*: int64
+    threadId*: int64
     profile*: Profile
     text*: string
     time*: Time
@@ -159,7 +159,7 @@ type
 
   Chain* = ref object
     content*: seq[Tweet]
-    more*: int
+    more*: int64
 
   Conversation* = ref object
     tweet*: Tweet

--- a/src/views/timeline.nim
+++ b/src/views/timeline.nim
@@ -45,7 +45,7 @@ proc renderThread(thread: seq[Tweet]; prefs: Prefs; path: string): VNode =
       renderTweet(tweet, prefs, path, class=(header & "thread"),
                   index=i, total=thread.high, showThread=show)
 
-proc threadFilter(it: Tweet; thread: int): bool =
+proc threadFilter(it: Tweet; thread: int64): bool =
   it.retweet.isNone and it.reply.len == 0 and it.threadId == thread
 
 proc renderUser(user: Profile; prefs: Prefs): VNode =
@@ -88,8 +88,8 @@ proc renderTimelineTweets*(results: Result[Tweet]; prefs: Prefs; path: string): 
     if results.content.len == 0:
       renderNoneFound()
     else:
-      var threads: seq[int]
-      var retweets: seq[int]
+      var threads: seq[int64]
+      var retweets: seq[int64]
       for tweet in results.content:
         if tweet.threadId in threads or tweet.id in retweets: continue
         if tweet.pinned and prefs.hidePins: continue


### PR DESCRIPTION
I was trying to run this on 32-bit ARM and I got crashes like this when trying to view timelines:

```
An error has occured in one of your routes.

Detail: /var/src/nitter/src/nitter.nim(31) nitter
/tmp/nimble_7622/githubcom_dom96jester_0.4.3/jester.nim(482) serve
/var/src/nitter/.nimble/pkgs/httpbeast-#head/httpbeast.nim(430) run
/var/src/nitter/.nimble/pkgs/httpbeast-#head/httpbeast.nim(292) eventLoop
/var/src/nitter/.nimble/pkgs/httpbeast-#head/httpbeast.nim(171) processEvents
/usr/lib/nim/pure/asyncdispatch.nim(1569) poll
/usr/lib/nim/pure/asyncdispatch.nim(1335) runOnce
/usr/lib/nim/pure/asyncdispatch.nim(210) processPendingCallbacks
/usr/lib/nim/pure/asyncmacro.nim(34) getProfileAndTimelineNimAsyncContinue
/var/src/nitter/src/api/timeline.nim(35) getProfileAndTimelineIter
/var/src/nitter/src/parser.nim(192) parseTimeline
/var/src/nitter/src/parser.nim(145) parseChain
/var/src/nitter/src/parser.nim(102) parseTweet
/usr/lib/nim/pure/strutils.nim(1098) parseInt
/usr/lib/nim/pure/parseutils.nim(466) parseInt
/usr/lib/nim/pure/parseutils.nim(401) integerOutOfRangeError
[...]
Exception message: Parsed integer outside of valid range
```

Any of these "primary-key" ID types need to explicitly int64, otherwise they will default to 32-bit ints which are not big enough to fit tweet IDs. I made those changes and it seems to be working now.