### PR TITLE
List library depencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Twitter account.
 
 ## Installation
 
+### Dependencies
+ * libsqlite3
+ * libpcre
+
 To compile Nitter you need a Nim installation, see
 [nim-lang.org](https://nim-lang.org/install.html) for details. It is possible to
 install it system-wide or in the user directory you create below.


### PR DESCRIPTION
On some systems, some required libraries are not installed by default. List them to ease installation.