### PR TITLE
Add nitter light theme

### DIFF
--- a/public/css/themes/nitter_light.css
+++ b/public/css/themes/nitter_light.css
@@ -1,0 +1,37 @@
+body {
+    --bg_color: #F0ECE6;
+    --fg_color: #0F0F0F;
+    --fg_faded: #657786;
+    --fg_dark: var(--accent);
+    --fg_nav: var(--accent);
+
+    --bg_panel: #FFFFFF;
+    --bg_elements: #FDFDFD;
+    --bg_overlays: #FFFFFF;
+    --bg_hover: #FAF9F5;
+
+    --grey: var(--fg_faded);
+    --dark_grey: #D6D6D6;
+    --darker_grey: #CECECE;
+    --darkest_grey: #ECECEC;
+    --border_grey: #F0ECE6;
+
+    --accent: #FF6C60;
+    --accent_light: #FFACA0;
+    --accent_dark: var(--accent);
+    --accent_border: #FF6C6091;
+
+    --play_button: #D84D4D;
+    --play_button_hover: #FF6C60;
+
+    --more_replies_dots: #AD433B;
+    --error_red: #FF7266;
+
+    --verified_blue: #1DA1F2;
+    --icon_text: #F8F8F2;
+
+    --tab: var(--accent);
+    --tab_selected: #000000;
+
+    --profile_stat: var(--fg_dark);
+}


### PR DESCRIPTION
There is only one light theme in nitter, along with many dark theme.
The problem is there is too much blue in twitter light theme, it's aggressive.
Therefore I've made this nitter light theme. Based on twitter light and nitter themes.

Here are some screenshots:
![homepage](https://user-images.githubusercontent.com/58657617/81968499-bfd6d680-961c-11ea-83c7-c49c42165228.png)
![search](https://user-images.githubusercontent.com/58657617/81968451-b2b9e780-961c-11ea-99ff-a07d6e65d004.png)
![mozilla](https://user-images.githubusercontent.com/58657617/81968473-b8173200-961c-11ea-9c82-f89ed2f2f8b1.png)
![preferences](https://user-images.githubusercontent.com/58657617/81968464-b51c4180-961c-11ea-87d3-efe785424207.png)
![error](https://user-images.githubusercontent.com/58657617/81968505-c2d1c700-961c-11ea-82b5-ba0ab4d52117.png)

Feel free to suggest improvements!