### PR TITLE
Image URL encoding

### DIFF
--- a/nitter.conf
+++ b/nitter.conf
@@ -20,6 +20,7 @@ redisMaxConnections = 30
 
 [Config]
 hmacKey = "secretkey" # random key for cryptographic signing of video urls
+compatiblePicURL = false  # Generate compatible picture URL
 tokenCount = 10
 # minimum amount of usable tokens. tokens are used to authorize API requests,
 # but they expire after ~1 hour, and have a limit of 187 requests.

--- a/src/config.nim
+++ b/src/config.nim
@@ -30,6 +30,7 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
     redisMaxConns: cfg.get("Cache", "redisMaxConnections", 30),
 
     hmacKey: cfg.get("Config", "hmacKey", "secretkey"),
+    compatiblePicURL: cfg.get("Config", "compatiblePicURL", false),
     minTokens: cfg.get("Config", "tokenCount", 10),
   )
 

--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -23,6 +23,7 @@ stdout.flushFile
 updateDefaultPrefs(fullCfg)
 setCacheTimes(cfg)
 setHmacKey(cfg.hmacKey)
+setCompatiblePicUrl(cfg.compatiblePicURL)
 
 waitFor initRedisPool(cfg)
 stdout.write &"Connected to Redis at {cfg.redisHost}:{cfg.redisPort}\n"

--- a/src/types.nim
+++ b/src/types.nim
@@ -201,6 +201,7 @@ type
     staticDir*: string
 
     hmacKey*: string
+    compatiblePicURL*: bool
     minTokens*: int
 
     cacheDir*: string

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -2,6 +2,7 @@ import strutils, strformat, sequtils, uri, tables
 import nimcrypto, regex
 
 var hmacKey = "secretkey"
+var compatiblePicURL = false
 
 const
   https* = "https://"
@@ -19,6 +20,9 @@ const
 
 proc setHmacKey*(key: string) =
   hmacKey = key
+
+proc setCompatiblePicUrl*(value: bool) =
+  compatiblePicURL = value
 
 proc getHmac*(data: string): string =
   ($hmac(sha256, hmacKey, data))[0 .. 12]

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -1,3 +1,4 @@
+import base64
 import strutils, strformat, sequtils, uri, tables
 import nimcrypto, regex
 
@@ -35,7 +36,11 @@ proc getVidUrl*(link: string): string =
   &"/video/{sig}/{url}"
 
 proc getPicUrl*(link: string): string =
-  &"/pic/{encodeUrl(link)}"
+  if compatiblePicURL:
+    # Use "safe" encoding mode: https://nim-lang.org/docs/base64.html#encode%2Cstring
+    &"/pic/encoded/{encodeUrl(encode(link, safe = true))}"
+  else:
+    &"/pic/{encodeUrl(link)}"
 
 proc cleanFilename*(filename: string): string =
   const reg = re"[^A-Za-z0-9._-]"


### PR DESCRIPTION
The option is named `compatiblePicURL`, used base64.

I don't know enough Nim to get this to compile though. `@"encoded"` is not a string apparently, so the base64 decoder can't eat that.