### PR TITLE
systemd unit: use default.target instead of multi-user.target

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Restart=always
 RestartSec=15
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=default.target
 ```
 
 Then enable and run the service:


### PR DESCRIPTION
Not all systems have their default.target aliased to multi-user.target.
End-user machines, for instance, may have it set to graphical.target.

systemd.special(7) defines default.target as
"the default unit systemd starts at bootup.
Usually, this should be aliased (symlinked) to
multi-user.target or graphical.target."