### PR TITLE
Add a docker-compose file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.*
+*.png
+*.md
+LICENSE
+docker-compose.yml
+Dockerfile
+tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM nimlang/nim:alpine as nim
-MAINTAINER setenforce@protonmail.com
+LABEL maintainer="setenforce@protonmail.com"
 EXPOSE 8080
 
 RUN apk --no-cache add libsass-dev libffi-dev openssl-dev redis openssh-client
@@ -11,9 +11,9 @@ RUN nimble build -y -d:release --passC:"-flto" --passL:"-flto" \
     && strip -s nitter \
     && nimble scss
 
-FROM redis:6-alpine
+FROM alpine:latest
 WORKDIR /src/
-RUN apk --no-cache add pcre-dev sqlite-dev
-COPY --from=nim /src/nitter/nitter /src/nitter/start.sh /src/nitter/nitter.conf ./
+RUN apk --no-cache add pcre sqlite
+COPY --from=nim /src/nitter/nitter /src/nitter/nitter.conf ./
 COPY --from=nim /src/nitter/public ./public
-CMD ["./start.sh"]
+CMD ./nitter

--- a/README.md
+++ b/README.md
@@ -100,15 +100,23 @@ using the systemd service below. You should run Nitter behind a reverse proxy
 such as [Nginx](https://github.com/zedeus/nitter/wiki/Nginx) or Apache for
 security reasons.
 
+To run nitter with docker, you will need to install redis before you run these commands.
+
 To build and run Nitter in Docker:
 ```bash
 docker build -t nitter:latest .
-docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d -p 8080:8080 nitter:latest
+docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d --network host -p 8080:8080 nitter:latest
 ```
 
 A prebuilt Docker image is provided as well:
 ```bash
-docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d -p 8080:8080 zedeus/nitter:latest
+docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d --network host -p 8080:8080 zedeus/nitter:latest
+```
+
+Using docker-compose to run both nitter and redis as different containers:
+Change redisHost from `localhost` to `redis` in `nitter.conf` and then run:
+```bash
+docker-compose up -d
 ```
 
 Note the Docker commands expect a `nitter.conf` file in the directory you run them.

--- a/README.md
+++ b/README.md
@@ -100,20 +100,20 @@ using the systemd service below. You should run Nitter behind a reverse proxy
 such as [Nginx](https://github.com/zedeus/nitter/wiki/Nginx) or Apache for
 security reasons.
 
-To run nitter with docker, you will need to install redis before you run these commands.
+To run Nitter with docker, you will need to install Redis before you run these commands.
 
 To build and run Nitter in Docker:
 ```bash
 docker build -t nitter:latest .
-docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d --network host -p 8080:8080 nitter:latest
+docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d --network host nitter:latest
 ```
 
 A prebuilt Docker image is provided as well:
 ```bash
-docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d --network host -p 8080:8080 zedeus/nitter:latest
+docker run -v $(pwd)/nitter.conf:/src/nitter.conf -d --network host zedeus/nitter:latest
 ```
 
-Using docker-compose to run both nitter and redis as different containers:
+Using docker-compose to run both Nitter and Redis as different containers:
 Change redisHost from `localhost` to `redis` in `nitter.conf` and then run:
 ```bash
 docker-compose up -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: "3.8"
+services:
+  redis:
+    image: redis:6-alpine
+    restart: unless-stopped
+    volumes:
+      - redis-data:/var/lib/redis
+  nitter:
+    image: zedeus/nitter:latest
+    restart: unless-stopped
+    depends_on:
+      - redis
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./nitter.conf:/src/nitter.conf
+volumes:
+  redis-data:

--- a/nitter.conf
+++ b/nitter.conf
@@ -10,7 +10,7 @@ hostname = "nitter.net"
 [Cache]
 listMinutes = 240  # how long to cache list info (not the tweets, so keep it high)
 rssMinutes = 10  # how long to cache rss queries
-redisHost = "localhost"
+redisHost = "localhost" # Change to redis if using docker-compose
 redisPort = 6379
 redisConnections = 20 # connection pool size
 redisMaxConnections = 30

--- a/nitter.conf
+++ b/nitter.conf
@@ -10,7 +10,7 @@ hostname = "nitter.net"
 [Cache]
 listMinutes = 240  # how long to cache list info (not the tweets, so keep it high)
 rssMinutes = 10  # how long to cache rss queries
-redisHost = "localhost" # Change to redis if using docker-compose
+redisHost = "localhost" # Change to "redis" if using docker-compose
 redisPort = 6379
 redisConnections = 20 # connection pool size
 redisMaxConnections = 30

--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env sh
-
-nohup redis-server &
-./nitter


### PR DESCRIPTION
This allows people to have a persistent Redis database when using docker. You will now need to run Redis outside of docker if you use docker, this is not required when running with docker-compose.

This also reduces the nitter image size from 40MB to just 10MB, mainly because the Redis image which is no longer included.