### PR TITLE
[Dockerfile] Replace manual `apk update` w/ `--no-cache`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,7 @@ EXPOSE 8080
 COPY . /src/nitter
 WORKDIR /src/nitter
 
-RUN apk update \
-    && apk add libsass-dev libffi-dev openssl-dev redis \
+RUN apk --no-cache add libsass-dev libffi-dev openssl-dev redis \
     && nimble build -y -d:release --passC:"-flto" --passL:"-flto" \
     && strip -s nitter \
     && nimble scss


### PR DESCRIPTION
Just like the second apk command: `RUN apk --no-cache add pcre-dev sqlite-dev`!

Use `--no-cache` will save the `apk update` step, also leave no cache file and have a smaller image!