### PR TITLE
Refactor Dockerfile, separate and move `apk add` upper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM nimlang/nim:1.2.8-alpine as nim
 MAINTAINER setenforce@protonmail.com
 EXPOSE 8080
 
+RUN apk --no-cache add libsass-dev libffi-dev openssl-dev redis
+
 COPY . /src/nitter
 WORKDIR /src/nitter
 
-RUN apk --no-cache add libsass-dev libffi-dev openssl-dev redis \
-    && nimble build -y -d:release --passC:"-flto" --passL:"-flto" \
+RUN nimble build -y -d:release --passC:"-flto" --passL:"-flto" \
     && strip -s nitter \
     && nimble scss
 


### PR DESCRIPTION
This will allow Docker to cache the pacakges apk added, which saves the
bandwidth and time to build this Docker image.