### PR TITLE
Use JSON notation for CMD's arguments in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR /src/
 RUN apk --no-cache add pcre-dev sqlite-dev
 COPY --from=nim /src/nitter/nitter /src/nitter/start.sh /src/nitter/nitter.conf ./
 COPY --from=nim /src/nitter/public ./public
-CMD ./start.sh
+CMD ["./start.sh"]


### PR DESCRIPTION
Reference - Best practices for writing Dockerfiles:

- https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#cmd

> CMD should almost always be used in the form of CMD ["executable","param1", "param2"…]