### PR TITLE
Removed sentence about Twitter's legacy non-JS mobile mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,10 @@ maintained by the community.
 
 ## Why?
 
-It's basically impossible to use Twitter without JavaScript enabled. If you try,
-you're redirected to the legacy mobile version which is awful both functionally
-and aesthetically. For privacy-minded folks, preventing JavaScript analytics and
-potential IP-based tracking is important, but apart from using the legacy mobile
-version and a VPN, it's impossible. This is is especially relevant now that Twitter
+It's basically impossible to use Twitter without JavaScript enabled. For privacy-minded folks,
+preventing JavaScript analytics and potential IP-based tracking is important,
+but apart from using the legacy mobile version and a VPN, it's impossible.
+This is is especially relevant now that Twitter
 [removed the ability](https://www.eff.org/deeplinks/2020/04/twitter-removes-privacy-option-and-shows-why-we-need-strong-privacy-laws)
 for users to control whether their data gets sent to advertisers.
 


### PR DESCRIPTION
Twitter removed 15dec2020: https://libredd.it/r/Twitter/comments/k28b6w/legacy_mobile_twitter_version_will_shut_down_on/

Another sentence remains, mentioning both legacy mobile /and/ VPN, and I don't know what y'all wanna do with it. A VPN isn't enough? Mention TOR? =)