### PR TITLE
Add a home timeline for followed accounts

### DIFF
--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -9,7 +9,7 @@ import jester
 import types, config, prefs, formatters, redis_cache, http_pool, tokens
 import views/[general, about]
 import routes/[
-  preferences, timeline, status, media, search, rss, list, debug,
+  home, preferences, timeline, status, media, search, rss, list, debug,
   unsupported, embed, resolver, router_utils]
 
 const instancesUrl = "https://github.com/zedeus/nitter/wiki/Instances"
@@ -58,9 +58,6 @@ settings:
   bindAddr = cfg.address
 
 routes:
-  get "/":
-    resp renderMain(renderSearch(), request, cfg, themePrefs())
-
   get "/about":
     resp renderMain(renderAbout(), request, cfg, themePrefs())
 
@@ -90,6 +87,7 @@ routes:
     resp Http429, showError(
       &"Instance has been rate limited.<br>Use {link} or try again later.", cfg)
 
+  extend home, ""
   extend unsupported, ""
   extend preferences, ""
   extend resolver, ""

--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -10,7 +10,7 @@ import types, config, prefs, formatters, redis_cache, http_pool, tokens
 import views/[general, about]
 import routes/[
   home, preferences, timeline, status, media, search, rss, list, debug,
-  unsupported, embed, resolver, router_utils]
+  unsupported, embed, resolver, router_utils, follow]
 
 const instancesUrl = "https://github.com/zedeus/nitter/wiki/Instances"
 const issuesUrl = "https://github.com/zedeus/nitter/issues"
@@ -88,6 +88,7 @@ routes:
       &"Instance has been rate limited.<br>Use {link} or try again later.", cfg)
 
   extend home, ""
+  extend follow, ""
   extend unsupported, ""
   extend preferences, ""
   extend resolver, ""

--- a/src/prefs_impl.nim
+++ b/src/prefs_impl.nim
@@ -50,6 +50,11 @@ macro genPrefs*(prefDsl: untyped) =
     const `name`*: PrefList = toOrderedTable(`table`)
 
 genPrefs:
+  Timeline:
+    following(input, ""):
+      "A comma-separated list of users to follow."
+      placeholder: "one,two,three"
+
   Display:
     theme(select, "Nitter"):
       "Theme"

--- a/src/routes/follow.nim
+++ b/src/routes/follow.nim
@@ -8,6 +8,8 @@ proc addUserToFollowing*(following, toAdd: string): string =
   var updated = following.split(",")
   if updated == @[""]:
     return toAdd
+  elif toAdd in updated:
+    return following
   else:
     updated = concat(updated, @[toAdd])
     result = updated.join(",")

--- a/src/routes/follow.nim
+++ b/src/routes/follow.nim
@@ -1,12 +1,40 @@
-import jester
-import asyncdispatch, strutils, options, router_utils
-import ".."/[prefs, types, utils, redis_cache]
+import jester, asyncdispatch, strutils, sequtils
+import router_utils
+import ../types
 
 export follow
 
+proc addUserToFollowing*(following, toAdd: string): string =
+  var updated = following.split(",")
+  if updated == @[""]:
+    return toAdd
+  else:
+    updated = concat(updated, @[toAdd])
+    result = updated.join(",")
+
+proc removeUserFromFollowing*(following, remove: string): string =
+  var updated = following.split(",")
+  if updated == @[""]:
+    return ""
+  else:
+    updated = filter(updated, proc(x: string): bool = x != remove)
+    result = updated.join(",")
+
 proc createFollowRouter*(cfg: Config) =
   router follow:
-    post "/follow":
+    post "/follow/@name":
+      let
+        following = cookiePrefs().following
+        toAdd = @"name"
+        updated = addUserToFollowing(following, toAdd)
+      setCookie("following", updated, daysForward(360),
+                httpOnly=true, secure=cfg.useHttps, path="/")
       redirect(refPath())
-    post "/unfollow":
+    post "/unfollow/@name":
+      let
+        following = cookiePrefs().following
+        remove = @"name"
+        updated = removeUserFromFollowing(following, remove)
+      setCookie("following", updated, daysForward(360),
+                httpOnly=true, secure=cfg.useHttps, path="/")
       redirect(refPath())

--- a/src/routes/follow.nim
+++ b/src/routes/follow.nim
@@ -1,0 +1,12 @@
+import jester
+import asyncdispatch, strutils, options, router_utils
+import ".."/[prefs, types, utils, redis_cache]
+
+export follow
+
+proc createFollowRouter*(cfg: Config) =
+  router follow:
+    post "/follow":
+      redirect(refPath())
+    post "/unfollow":
+      redirect(refPath())

--- a/src/routes/home.nim
+++ b/src/routes/home.nim
@@ -1,0 +1,11 @@
+import jester
+import asyncdispatch, strutils, options, router_utils
+import ".."/[prefs, types, utils]
+import ../views/[general, home]
+
+export home
+
+proc createHomeRouter*(cfg: Config) =
+  router home:
+    get "/":
+      resp renderMain(renderHome(), request, cfg, themePrefs())

--- a/src/routes/home.nim
+++ b/src/routes/home.nim
@@ -10,7 +10,7 @@ proc showHome*(request: Request; query: Query; cfg: Config; prefs: Prefs;
   let
     timeline = await getSearch[Tweet](query, after)
     html = renderHome(timeline, prefs, getPath())
-  return renderMain(html, request, cfg, prefs, "Multi")
+  return renderMain(html, request, cfg, prefs)
 
 proc createHomeRouter*(cfg: Config) =
   router home:

--- a/src/routes/home.nim
+++ b/src/routes/home.nim
@@ -1,11 +1,40 @@
 import jester
-import asyncdispatch, strutils, options, router_utils
+import asyncdispatch, strutils, options, router_utils, timeline
 import ".."/[prefs, types, utils]
-import ../views/[general, home]
+import ../views/[general, home, search]
 
 export home
 
 proc createHomeRouter*(cfg: Config) =
   router home:
     get "/":
-      resp renderMain(renderHome(), request, cfg, themePrefs())
+      let
+        prefs = cookiePrefs()
+        after = getCursor()
+        names = getNames(prefs.following)
+
+      var query = request.getQuery("", prefs.following)
+      if names.len != 1:
+        query.fromUser = names
+
+      if @"scroll".len > 0:
+        if query.fromUser.len != 1:
+          var timeline = await getSearch[Tweet](query, after)
+          if timeline.content.len == 0: resp Http404
+          timeline.beginning = true
+          resp $renderTweetSearch(timeline, prefs, getPath())
+        else:
+          var (_, timeline, _) = await fetchSingleTimeline(after, query, skipRail=true)
+          if timeline.content.len == 0: resp Http404
+          timeline.beginning = true
+          resp $renderTimelineTweets(timeline, prefs, getPath())
+
+      var rss = "/$1/$2/rss" % [@"name", @"tab"]
+      if @"tab".len == 0:
+        rss = "/$1/rss" % @"name"
+      elif @"tab" == "search":
+        rss &= "?" & genQueryUrl(query)
+      
+      if names.len == 0:
+        resp renderMain(renderSearch(), request, cfg, themePrefs())
+      respTimeline(await showTimeline(request, query, cfg, prefs, rss, after))

--- a/src/routes/home.nim
+++ b/src/routes/home.nim
@@ -37,13 +37,13 @@ proc createHomeRouter*(cfg: Config) =
         prefs = cookiePrefs()
         names = getNames(prefs.following)
       var
-        profs: seq[Profile]
+        profs: seq[User]
         query = request.getQuery("", prefs.following)
       query.fromUser = names
       query.kind = userList
       
       for name in names:
-        let prof = await getCachedProfile(name)
+        let prof = await getCachedUser(name)
         profs &= @[prof]
 
       resp renderMain(renderFollowing(query, profs, prefs), request, cfg, prefs)

--- a/src/sass/profile/card.scss
+++ b/src/sass/profile/card.scss
@@ -13,9 +13,12 @@
     width: 100%;
 }
 
-.profile-card-tabs-name {
+.profile-card-tabs-name-and-follow {
     @include breakable;
-    max-width: 100%;
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
 }
 
 .profile-card-username {
@@ -32,6 +35,10 @@
     font-weight: bold;
     text-shadow: none;
     max-width: 100%;
+}
+
+.profile-card-follow-button {
+    float: none;
 }
 
 .profile-card-avatar {

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -1,4 +1,4 @@
-import karax/[karaxdsl, vdom], strutils
+import karax/[karaxdsl, vdom]
 import search, timeline, renderutils
 import ../types
 

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -1,7 +1,15 @@
-import karax/[karaxdsl, vdom]
+import karax/[karaxdsl, vdom], strutils
+import search, timeline
 import ../types
 
-proc renderHome*(): VNode =
-  buildHtml(tdiv(class="overlay-panel")):
-    h2: text "Timeline"
-    p: text "Coming soon!"
+proc renderHome*(results: Result[Tweet]; prefs: Prefs; path: string): VNode =
+  let query = results.query
+  buildHtml(tdiv(class="timeline-container")):
+    if query.fromUser.len > 0:
+      renderProfileTabs(query, query.fromUser.join(","))
+
+    if query.fromUser.len == 0 or query.kind == tweets:
+      tdiv(class="timeline-header"):
+        renderSearchPanel(query)
+
+    renderTimelineTweets(results, prefs, path)

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -1,15 +1,32 @@
 import karax/[karaxdsl, vdom], strutils
-import search, timeline
+import search, timeline, renderutils
 import ../types
+
+proc renderFollowingUsers*(results: seq[Profile]; prefs: Prefs): VNode =
+  buildHtml(tdiv(class="timeline")):
+    for user in results:
+      renderUser(user, prefs)
+
+proc renderHomeTabs*(query: Query): VNode =
+  buildHtml(ul(class="tab")):
+    li(class=query.getTabClass(posts)):
+      a(href="/"): text "Tweets"
+    li(class=query.getTabClass(userList)):
+      a(href=("/following")): text "Following"
 
 proc renderHome*(results: Result[Tweet]; prefs: Prefs; path: string): VNode =
   let query = results.query
   buildHtml(tdiv(class="timeline-container")):
     if query.fromUser.len > 0:
-      renderProfileTabs(query, query.fromUser.join(","))
+      renderHomeTabs(query)
 
     if query.fromUser.len == 0 or query.kind == tweets:
       tdiv(class="timeline-header"):
         renderSearchPanel(query)
 
     renderTimelineTweets(results, prefs, path)
+
+proc renderFollowing*(query: Query; following: seq[Profile]; prefs: Prefs): VNode =
+  buildHtml(tdiv(class="timeline-container")):
+    renderHomeTabs(query)
+    renderFollowingUsers(following, prefs)

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -1,0 +1,7 @@
+import karax/[karaxdsl, vdom]
+import ../types
+
+proc renderHome*(): VNode =
+  buildHtml(tdiv(class="overlay-panel")):
+    h2: text "Timeline"
+    p: text "Coming soon!"

--- a/src/views/home.nim
+++ b/src/views/home.nim
@@ -2,7 +2,7 @@ import karax/[karaxdsl, vdom]
 import search, timeline, renderutils
 import ../types
 
-proc renderFollowingUsers*(results: seq[Profile]; prefs: Prefs): VNode =
+proc renderFollowingUsers*(results: seq[User]; prefs: Prefs): VNode =
   buildHtml(tdiv(class="timeline")):
     for user in results:
       renderUser(user, prefs)
@@ -26,7 +26,7 @@ proc renderHome*(results: Result[Tweet]; prefs: Prefs; path: string): VNode =
 
     renderTimelineTweets(results, prefs, path)
 
-proc renderFollowing*(query: Query; following: seq[Profile]; prefs: Prefs): VNode =
+proc renderFollowing*(query: Query; following: seq[User]; prefs: Prefs): VNode =
   buildHtml(tdiv(class="timeline-container")):
     renderHomeTabs(query)
     renderFollowingUsers(following, prefs)

--- a/src/views/profile.nim
+++ b/src/views/profile.nim
@@ -30,9 +30,9 @@ proc renderUserCard*(user: User; prefs: Prefs; path: string): VNode =
           linkUser(user, class="profile-card-username")
         let following = isFollowing(user.username, prefs.following)
         if not following:
-          buttonReferer "/follow", "Follow", path, "profile-card-follow-button"
+          buttonReferer "/follow/" & profile.username, "Follow", path, "profile-card-follow-button"
         else:
-          buttonReferer "/unfollow", "Unfollow", path, "profile-card-follow-button"
+          buttonReferer "/unfollow/" & profile.username, "Unfollow", path, "profile-card-follow-button"
 
     tdiv(class="profile-card-extra"):
       if user.bio.len > 0:

--- a/src/views/profile.nim
+++ b/src/views/profile.nim
@@ -12,7 +12,7 @@ proc renderStat(num: int; class: string; text=""): VNode =
     span(class="profile-stat-num"):
       text insertSep($num, ',')
 
-proc renderUserCard*(user: User; prefs: Prefs): VNode =
+proc renderUserCard*(user: User; prefs: Prefs; path: string): VNode =
   buildHtml(tdiv(class="profile-card")):
     tdiv(class="profile-card-info"):
       let
@@ -24,9 +24,15 @@ proc renderUserCard*(user: User; prefs: Prefs): VNode =
       a(class="profile-card-avatar", href=url, target="_blank"):
         genImg(user.getUserPic(size))
 
-      tdiv(class="profile-card-tabs-name"):
-        linkUser(user, class="profile-card-fullname")
-        linkUser(user, class="profile-card-username")
+      tdiv(class="profile-card-tabs-name-and-follow"):
+        tdiv():
+          linkUser(user, class="profile-card-fullname")
+          linkUser(user, class="profile-card-username")
+        let following = isFollowing(user.username, prefs.following)
+        if not following:
+          buttonReferer "/follow", "Follow", path, "profile-card-follow-button"
+        else:
+          buttonReferer "/unfollow", "Unfollow", path, "profile-card-follow-button"
 
     tdiv(class="profile-card-extra"):
       if user.bio.len > 0:
@@ -106,7 +112,7 @@ proc renderProfile*(profile: var Profile; prefs: Prefs; path: string): VNode =
 
     let sticky = if prefs.stickyProfile: " sticky" else: ""
     tdiv(class=(&"profile-tab{sticky}")):
-      renderUserCard(profile.user, prefs)
+      renderUserCard(profile.user, prefs, path)
       if profile.photoRail.len > 0:
         renderPhotoRail(profile)
 

--- a/src/views/profile.nim
+++ b/src/views/profile.nim
@@ -30,9 +30,9 @@ proc renderUserCard*(user: User; prefs: Prefs; path: string): VNode =
           linkUser(user, class="profile-card-username")
         let following = isFollowing(user.username, prefs.following)
         if not following:
-          buttonReferer "/follow/" & profile.username, "Follow", path, "profile-card-follow-button"
+          buttonReferer "/follow/" & user.username, "Follow", path, "profile-card-follow-button"
         else:
-          buttonReferer "/unfollow/" & profile.username, "Unfollow", path, "profile-card-follow-button"
+          buttonReferer "/unfollow/" & user.username, "Unfollow", path, "profile-card-follow-button"
 
     tdiv(class="profile-card-extra"):
       if user.bio.len > 0:

--- a/src/views/renderutils.nim
+++ b/src/views/renderutils.nim
@@ -94,3 +94,7 @@ proc getAvatarClass*(prefs: Prefs): string =
     "avatar"
   else:
     "avatar round"
+
+proc isFollowing*(name, following: string): bool =
+  let following = following.split(",")
+  return name in following

--- a/src/views/timeline.nim
+++ b/src/views/timeline.nim
@@ -57,7 +57,7 @@ proc threadFilter(tweets: openArray[Tweet]; threads: openArray[int64]; it: Tweet
     elif t.replyId == result[0].id:
       result.add t
 
-proc renderUser(user: User; prefs: Prefs): VNode =
+proc renderUser*(user: User; prefs: Prefs): VNode =
   buildHtml(tdiv(class="timeline-item")):
     a(class="tweet-link", href=("/" & user.username))
     tdiv(class="tweet-body profile-result"):


### PR DESCRIPTION
This PR introduces a cookie-based system for following Twitter users via Nitter. Followed accounts are stored in a cookie (à la Teddit), and displayed at the base path.

- **New Routes**
  - `home.nim`
    - Served at the base path (`/`)
    - Shows a search box (as before) if the user is not following anybody
    - If the user is following anyone on Twitter, it instead shows a timeline. There's an additional tab available to list the users you are following (similar to the current `lists.nim` view).
  - `follow.nim`
    - Includes two routes, served at `/follow/@name` and `/unfollow/@name`
    - Similar to the `/enablehls` route, navigating to these pages modifies a cookie and then redirects the user back to the referrer.
    - As expected, the `/follow/@name` route adds a user to the `following` cookie and `/unfollow/@name` removes them.
- **New Preferences**
  - `following`
    - The `following` cookie, in the new "Timeline" section, is a comma-separated list of usernames to follow.
    - Exposing it directly through the `/settings` route enables users to quickly and easily transfer instances while keeping their list of followers.