### PR TITLE
Hack in support for the new twitter video format

### DIFF
--- a/src/formatters.nim
+++ b/src/formatters.nim
@@ -11,7 +11,7 @@ const
 
   wwwRegex = re"https?://(www[0-9]?\.)?"
   m3u8Regex = re"""url="(.+.m3u8)""""
-  manifestRegex = re"(.+(.ts|.m3u8|.vmap))"
+  manifestRegex = re"\/(.+(.ts|.m4s|.m3u8|.vmap|.mp4))"
   userpicRegex = re"_(normal|bigger|mini|200x200|400x400)(\.[A-z]+)$"
   extRegex = re"(\.[A-z]+)$"
   illegalXmlRegex = re"[^\x09\x0A\x0D\x20-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]"
@@ -61,7 +61,7 @@ proc getM3u8Url*(content: string): string =
 
 proc proxifyVideo*(manifest: string; proxy: bool): string =
   proc cb(m: RegexMatch; s: string): string =
-    result = "https://video.twimg.com" & s[m.group(0)[0]]
+    result = "https://video.twimg.com/" & s[m.group(0)[0]]
     if proxy: result = getVidUrl(result)
   result = manifest.replace(manifestRegex, cb)
 

--- a/src/routes/media.nim
+++ b/src/routes/media.nim
@@ -109,7 +109,7 @@ proc createMediaRouter*(cfg: Config) =
       if getHmac(url) != request.matches[1]:
         resp showError("Failed to verify signature", cfg)
 
-      if ".mp4" in url or ".ts" in url:
+      if ".mp4" in url or ".ts" in url or ".m4s" in url:
         let code = await proxyMedia(request, url)
         check code
 


### PR DESCRIPTION
This change adds ".m4s" and ".mp4" to the regex that modifies m3u8 playlist files proxied from twitter, and adds ".m4s" to the list of extensions proxied through nitter. The net effect is the new video format that twitter is using now should be supported.

I'm not sure if this is the way you want to officially add support, but it seems to work well after a few days of testing on my instance.