### PR TITLE
Changed procedure getRfc822Time to comply with RSS 2.0 spec

### DIFF
--- a/src/formatters.nim
+++ b/src/formatters.nim
@@ -97,7 +97,7 @@ proc getTime*(tweet: Tweet): string =
   tweet.time.format("d/M/yyyy', 'HH:mm:ss")
 
 proc getRfc822Time*(tweet: Tweet): string =
-  tweet.time.format("ddd', 'd MMM yyyy HH:mm:ss 'GMT'")
+  tweet.time.format("ddd', 'dd MMM yyyy HH:mm:ss 'GMT'")
 
 proc getTweetTime*(tweet: Tweet): string =
   tweet.time.format("h:mm tt' · 'MMM d', 'YYYY")


### PR DESCRIPTION
This PR changes getRfc822Time to comply with the RSS specification.

The procedure getRfc822Time is currently used only to generate the publication date (pubDate) in RSS feeds. The procedure outputs the day of the month as one or two digits depending on the day, contrary to the [RSS 2.0 specification](https://www.rssboard.org/rss-specification) which requires two digits.