### PR TITLE
Allow either integer or string values for guest_token in activate response.

### DIFF
--- a/src/tokens.nim
+++ b/src/tokens.nim
@@ -36,11 +36,13 @@ proc fetchToken(): Future[Token] {.async.} =
 
   var
     resp: string
+    tokNode: JsonNode
     tok: string
 
   try:
     resp = clientPool.use(headers): await c.postContent(activate)
-    tok = parseJson(resp)["guest_token"].getStr
+    tokNode = parseJson(resp)["guest_token"]
+    tok = tokNode.getStr($(tokNode.getInt))
 
     let time = getTime()
     result = Token(tok: tok, remaining: 187, reset: time + resetPeriod,


### PR DESCRIPTION
I've recently started running into rate limiting errors (e.g. `rate limited with 10 tokens, average remaining: 186`) on a low traffic self-hosted instance.  It appears that the cause is Twitter's `activate` endpoint returning inconsistent JSON:

```
{"guest_token":1410409329899888640}
{"guest_token":"1410409329916715009"}
{"guest_token":"1410409329937698816"}
{"guest_token":1410409329975390208}
{"guest_token":1410409338473107463}
```

The numeric values were getting turned into empty strings, causing [this check](https://github.com/zedeus/nitter/blob/master/src/apiutils.nim#L39) to fail.

I'm not sure if there's a better way to do this in Nim, but this change allows either the string or int version of the token to be parsed.