### PR TITLE
Add security headers and a strict Content Security Policy (CSP)

### DIFF
--- a/src/routes/media.nim
+++ b/src/routes/media.nim
@@ -54,7 +54,12 @@ proc proxyMedia*(req: jester.Request; url: string): Future[HttpCode] {.async.} =
       "Content-Type": res.headers["content-type", 0],
       "Content-Length": contentLength,
       "Cache-Control": maxAge,
-      "ETag": hashed
+      "ETag": hashed,
+      "x-frame-options": "DENY",
+      "x-content-type-options": "nosniff",
+      "referrer-policy": "no-referrer",
+      "permissions-policy": "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=()",
+      "content-security-policy": "default-src 'none'; img-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' blob:; font-src 'self'; media-src 'self' blob:; base-uri 'none'; frame-ancestors 'none'; form-action 'self'; connect-src'self'; upgrade-insecure-requests;"
     })
 
     respond(request, headers)


### PR DESCRIPTION
How the headers increase user security/privacy: 

- `x-frame-options` -  Indicates whether the browser should allow the webpage to be displayed in a frame within another webpage.
- `x-content-type-options` - Prevents Internet Explorer from MIME-sniffing a response away from the declared content-type.
- `referrer-policy` - Controls how much referrer information (sent via the Referrer header) should be included with requests. 
- `permissions-policy` - Controls what browser features can be used (The configuration added disables all features).
- `content-security-policy` (CSP) - Restricts where resources can be loaded from. This will prevent an accidental connection to twitter. 

More detail on the specific headers can be found at https://securityheaders.com

@pred2k Thanks for your example CSP provided with #355 

Related: #355 
