### PR TITLE
Set the tag of Docker base image: Redis to 6-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN nimble build -y -d:release --passC:"-flto" --passL:"-flto" \
     && strip -s nitter \
     && nimble scss
 
-FROM redis:6.0.4-alpine
+FROM redis:6-alpine
 WORKDIR /src/
 RUN apk --no-cache add pcre-dev sqlite-dev
 COPY --from=nim /src/nitter/nitter /src/nitter/start.sh /src/nitter/nitter.conf ./


### PR DESCRIPTION
Redis 6.0.4 is a little bit dated, there are some security
updates in the futures versions.

Set the image tag to 6-alpine, instead of 6.0.12-alpine or 6.2.1-alpine,
so that we don't need to manually follow the minor and patch versions
manually, will be more convenient.

(Could use with `--pull` parameter when building the image, so that
Docker will always check the latest 6-alpine)