### PR TITLE
Remove hardcoded default Piped/Invidious hostname

### DIFF
--- a/src/config.nim
+++ b/src/config.nim
@@ -33,9 +33,7 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
     redisPort: cfg.get("Cache", "redisPort", 6379),
     redisConns: cfg.get("Cache", "redisConnections", 20),
     redisMaxConns: cfg.get("Cache", "redisMaxConnections", 30),
-    redisPassword: cfg.get("Cache", "redisPassword", ""),
-
-    replaceYouTube: cfg.get("Preferences", "replaceYouTube", "piped.kavin.rocks")
+    redisPassword: cfg.get("Cache", "redisPassword", "")
   )
 
   return (conf, cfg)

--- a/src/prefs_impl.nim
+++ b/src/prefs_impl.nim
@@ -54,7 +54,7 @@ genPrefs:
       "Replace Twitter links with Nitter (blank to disable)"
       placeholder: "Nitter hostname"
 
-    replaceYouTube(input, "piped.kavin.rocks"):
+    replaceYouTube(input, ""):
       "Replace YouTube links with Piped/Invidious (blank to disable)"
       placeholder: "Piped hostname"
 


### PR DESCRIPTION
Since e183a9c, I noticed that when I use `replaceYouTube=""` in `nitter.conf`, Nitter transforms YouTube links anyway, using piped.kavin.rocks for the domain name. I was expecting for YouTube links to be left alone if that setting is blank, so disabling the link transforms is impossible without cookies.

This PR (my very first one here) addresses this behavior and should not break YouTube link transforms when `replaceYouTube` is already filled in the config. This can also be useful if an instance chooses to disable transforming YouTube links in RSS feeds.

**Edit:** I mixed up the initial observations with how Nitter handles the blank `replaceYouTube` setting, and in fact both RSS feeds and the settings page did use the default domain when it is blank in the config file. I still believe that it's more appropriate to define the default value in `nitter.conf` rather than hardcoding it.