### PR TITLE
Add dir="auto" to Search box

### DIFF
--- a/src/views/search.nim
+++ b/src/views/search.nim
@@ -24,7 +24,7 @@ proc renderSearch*(): VNode =
     tdiv(class="search-bar"):
       form(`method`="get", action="/search"):
         hiddenField("f", "users")
-        input(`type`="text", name="q", autofocus="", placeholder="Enter username...")
+        input(`type`="text", name="q", autofocus="", placeholder="Enter username...", dir="auto")
         button(`type`="submit"): icon "search"
 
 proc renderProfileTabs*(query: Query; username: string): VNode =


### PR DESCRIPTION
Fix RTL problem on search box.
Before:
![image](https://user-images.githubusercontent.com/53198048/132133309-d8a119ac-95a4-4eab-91d3-34fe993620f7.png)
After:
![image](https://user-images.githubusercontent.com/53198048/132133329-689ce60a-9125-4ba8-bb7a-839207ad87d1.png)

Computers support two kinds of text flow:

* "LTR": from left to right, like most western languages
* "RTL": from right to left, like Arabic, Persian and Hebrew