### PR TITLE
Disable Piped by default

### DIFF
--- a/src/prefs_impl.nim
+++ b/src/prefs_impl.nim
@@ -54,7 +54,7 @@ genPrefs:
       "Replace Twitter links with Nitter (blank to disable)"
       placeholder: "Nitter hostname"
 
-    replaceYouTube(input, "piped.kavin.rocks"):
+    replaceYouTube(input, ""):
       "Replace YouTube links with Piped/Invidious (blank to disable)"
       placeholder: "Piped hostname"
 


### PR DESCRIPTION
Currently, the default piped.kavin.rocks entry is set in two places: the distributed nitter.conf and the prefs_impl.nim which makes it impossible to disable piped as an instance default. Leaving blank in nitter.conf will still fall back to piped.kavin.rocks. I deleted this fallback while keeping the default entry in the distributed nitter.conf to get consistent behaviour with the Bibliogram field.