### PR TITLE
Allow disabling Piped/Invidious link transforms explicitly

### DIFF
--- a/nitter.conf
+++ b/nitter.conf
@@ -34,6 +34,8 @@ tokenCount = 10
 theme = "Nitter"
 replaceTwitter = "nitter.net"
 replaceYouTube = "piped.kavin.rocks"
+# domain name to use when transforming YouTube links into Piped/Invidious
+# links. Set the above value to a blank string ("") if you wish to disable it
 replaceInstagram = ""
 proxyVideos = true
 hlsPlayback = false

--- a/src/config.nim
+++ b/src/config.nim
@@ -2,8 +2,9 @@ import parsecfg except Config
 import types, strutils
 
 proc get*[T](config: parseCfg.Config; s, v: string; default: T): T =
-  let val = config.getSectionValue(s, v)
-  if val.len == 0: return default
+  let val = config.getSectionValue(s, v, $default)
+  if val.len == 0 and v != "replaceYouTube":
+    return default
 
   when T is int: parseInt(val)
   elif T is bool: parseBool(val)


### PR DESCRIPTION
This PR is a continuation of #432 and aims to fix a bug where setting `replaceYouTube` in `nitter.conf` to a blank string (`""`) still causes Nitter to transform YouTube links by default. When `replaceYouTube` is not found or commented out in the config file, Nitter should still transform such links using the default value of piped.kavin.rocks as a fallback.

CC @zedeus @selurvedu @grmat