### PR TITLE
enableRSS configuration setting

### DIFF
--- a/nitter.conf
+++ b/nitter.conf
@@ -28,6 +28,7 @@ tokenCount = 10
 # the limit gets reset every 15 minutes, and the pool is filled up so there's
 # always at least $tokenCount usable tokens. again, only increase this if
 # you receive major bursts all the time
+enableRSS = true  # set this to false to disable RSS feeds
 
 # Change default preferences here, see src/prefs_impl.nim for a complete list
 [Preferences]

--- a/src/config.nim
+++ b/src/config.nim
@@ -25,6 +25,7 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
     hmacKey: cfg.get("Config", "hmacKey", "secretkey"),
     base64Media: cfg.get("Config", "base64Media", false),
     minTokens: cfg.get("Config", "tokenCount", 10),
+    enableRSS: cfg.get("Config", "enableRSS", true),
 
     listCacheTime: cfg.get("Cache", "listMinutes", 120),
     rssCacheTime: cfg.get("Cache", "rssMinutes", 10),

--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -46,7 +46,8 @@ createStatusRouter(cfg)
 createSearchRouter(cfg)
 createMediaRouter(cfg)
 createEmbedRouter(cfg)
-createRssRouter(cfg)
+if cfg.enableRSS:
+  createRssRouter(cfg)
 
 settings:
   port = Port(cfg.port)

--- a/src/types.nim
+++ b/src/types.nim
@@ -126,7 +126,7 @@ type
     videoDirectMessage = "video_direct_message"
     imageDirectMessage = "image_direct_message"
     audiospace = "audiospace"
-    
+
   Card* = object
     kind*: CardKind
     id*: string
@@ -212,6 +212,7 @@ type
     hmacKey*: string
     base64Media*: bool
     minTokens*: int
+    enableRSS*: bool
 
     rssCacheTime*: int
     listCacheTime*: int

--- a/src/views/general.nim
+++ b/src/views/general.nim
@@ -10,7 +10,7 @@ const
   doctype = "<!DOCTYPE html>\n"
   lp = readFile("public/lp.svg")
 
-proc renderNavbar*(title, rss: string; req: Request): VNode =
+proc renderNavbar*(cfg: Config, rss: string; req: Request): VNode =
   let twitterPath = getTwitterLink(req.path, req.params)
   var path = $(parseUri(req.path) ? filterParams(req.params))
   if "/status" in path: path.add "#m"
@@ -18,13 +18,13 @@ proc renderNavbar*(title, rss: string; req: Request): VNode =
   buildHtml(nav):
     tdiv(class="inner-nav"):
       tdiv(class="nav-item"):
-        a(class="site-name", href="/"): text title
+        a(class="site-name", href="/"): text cfg.title
 
       a(href="/"): img(class="site-logo", src="/logo.png")
 
       tdiv(class="nav-item right"):
         icon "search", title="Search", href="/search"
-        if rss.len > 0:
+        if cfg.enableRSS and rss.len > 0:
           icon "rss-feed", title="RSS Feed", href=rss
         icon "bird", title="Open in Twitter", href=twitterPath
         a(href="https://liberapay.com/zedeus"): verbatim lp
@@ -57,7 +57,7 @@ proc renderHead*(prefs: Prefs; cfg: Config; titleText=""; desc=""; video="";
     link(rel="search", type="application/opensearchdescription+xml", title=cfg.title,
                             href=opensearchUrl)
 
-    if rss.len > 0:
+    if cfg.enableRSS and rss.len > 0:
       link(rel="alternate", type="application/rss+xml", href=rss, title="RSS feed")
 
     if prefs.hlsPlayback:
@@ -119,7 +119,7 @@ proc renderMain*(body: VNode; req: Request; cfg: Config; prefs=defaultPrefs;
     renderHead(prefs, cfg, titleText, desc, video, images, banner, ogTitle, theme, rss)
 
     body:
-      renderNavbar(cfg.title, rss, req)
+      renderNavbar(cfg, rss, req)
 
       tdiv(class="container"):
         body


### PR DESCRIPTION
Resolves #437.

This new setting is self-explanatory. By default, `enableRSS` is set to true, which enables the RSS endpoint and shows a link to a timeline's RSS feed on the header. If set to false, Nitter will hide the RSS link from the header, and RSS endpoints should return a 404 Not Found error.