### PR TITLE
Implement user_id to screen_name router

### DIFF
--- a/src/api.nim
+++ b/src/api.nim
@@ -40,6 +40,12 @@ proc getProfile*(username: string): Future[Profile] {.async.} =
     url = userShow ? ps
   result = parseUserShow(await fetch(url, oldApi=true), username)
 
+proc getProfileById*(userId: string): Future[Profile] {.async.} =
+  let
+    ps = genParams({"user_id": userId})
+    url = userShow ? ps
+  result = parseUserShowId(await fetch(url, oldApi=true), userId)
+
 proc getTimeline*(id: string; after=""; replies=false): Future[Timeline] {.async.} =
   let
     ps = genParams({"userId": id, "include_tweet_replies": $replies}, after)

--- a/src/parser.nim
+++ b/src/parser.nim
@@ -38,6 +38,18 @@ proc parseUserShow*(js: JsonNode; username: string): Profile =
 
   result = parseProfile(js)
 
+proc parseUserShowId*(js: JsonNode; userId: string): Profile =
+  if js.isNull:
+    return Profile(id: userId)
+
+  with error, js{"errors"}:
+    result = Profile(id: userId)
+    if error.getError == suspended:
+      result.suspended = true
+    return
+
+  result = parseProfile(js)
+
 proc parseGraphProfile*(js: JsonNode; username: string): Profile =
   if js.isNull: return
   with error, js{"errors"}:

--- a/src/routes/timeline.nim
+++ b/src/routes/timeline.nim
@@ -105,8 +105,22 @@ template respTimeline*(timeline: typed) =
     resp Http404, showError("User \"" & @"name" & "\" not found", cfg)
   resp t
 
+template respUserId*() =
+  cond @"user_id".len > 0
+  let username = await getCachedProfileScreenName(@"user_id")
+  if username.len > 0:
+    redirect("/" & username)
+  else:
+    resp Http404, showError("User not found", cfg)
+
 proc createTimelineRouter*(cfg: Config) =
   router timeline:
+    get "/i/user/@user_id":
+      respUserId()
+
+    get "/intent/user":
+      respUserId()
+
     get "/@name/?@tab?/?":
       cond '.' notin @"name"
       cond @"name" notin ["pic", "gif", "video"]

--- a/src/routes/unsupported.nim
+++ b/src/routes/unsupported.nim
@@ -11,10 +11,13 @@ proc createUnsupportedRouter*(cfg: Config) =
       resp renderMain(renderFeature(), request, cfg, themePrefs())
 
     get "/about/feature": feature()
-    get "/intent/?@i?": feature()
     get "/login/?@i?": feature()
     get "/@name/lists/?": feature()
 
+    get "/intent/?@i?": 
+      cond @"i" notin ["user"]
+      feature()
+
     get "/i/@i?/?@j?":
-      cond @"i" notin ["status", "lists"]
+      cond @"i" notin ["status", "lists" , "user"]
       feature()


### PR DESCRIPTION
Make a  redirection of  `/i/user/<user_id>` or `/intent/user?user_id=<user_id>` to  screen_name link `/<screen_name>

Add a new redis key for mapping from `user_id` to  `screen_name`

When fetching profile via user_id , we also cache the profile.
When caching the profile (via user_id or screen_name)  , we also cache the mapping from `user_id` to `screen_name`.

for #295 