### PR TITLE
Fix unescaped dot in Instagram regex

### DIFF
--- a/src/formatters.nim
+++ b/src/formatters.nim
@@ -5,7 +5,7 @@ import types, utils, query
 const
   ytRegex = re"([A-z.]+\.)?youtu(be\.com|\.be)"
   twRegex = re"(www\.|mobile\.)?twitter\.com"
-  igRegex = re"(www\.)?instagram.com"
+  igRegex = re"(www\.)?instagram\.com"
   cards = "cards.twitter.com/cards"
   tco = "https://t.co"
 


### PR DESCRIPTION
Similar to edb37511813ba803568a71de997031ed79ad5329 (#109)