### PR TITLE
Fix special tasks

### DIFF
--- a/nitter.nimble
+++ b/nitter.nimble
@@ -28,7 +28,7 @@ requires "jsony#d0e69bd"
 # Tasks
 
 task scss, "Generate css":
-  exec "nim c --hint[Processing]:off -d:danger -r tools/gencss"
+  exec "nimble c --hint[Processing]:off -d:danger -r tools/gencss"
 
 task md, "Render md":
-  exec "nim c --hint[Processing]:off -d:danger -r tools/rendermd"
+  exec "nimble c --hint[Processing]:off -d:danger -r tools/rendermd"


### PR DESCRIPTION
I get errors like this:

```
nitter-git/tools/gencss.nim(1, 8) Error: cannot open file: sass
stack trace: (most recent call last)
/tmp/nimblecache-798796522/nimscriptapi_3049515398.nim(187, 16)
nitter-git/nitter.nimble(31, 8) scssTask
/usr/lib/nim/system/nimscript.nim(260, 7) exec
/usr/lib/nim/system/nimscript.nim(260, 7) Error: unhandled exception: FAILED: nim c -r tools/gencss [OSError]
       Tip: 2 messages have been suppressed, use --verbose to show them.
     Error: Exception raised during nimble script execution
```