### PR TITLE
Enhance the compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080" # Replace with "8080:8080" if you don't use a reverse proxy
     volumes:
-      - ./nitter.conf:/src/nitter.conf
+      - ./nitter.conf:/src/nitter.conf:ro
     depends_on:
       - nitter-redis
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,18 +1,25 @@
-version: "3.8"
+version: "3"
+
 services:
-  redis:
-    image: redis:6-alpine
-    restart: unless-stopped
-    volumes:
-      - redis-data:/var/lib/redis
+
   nitter:
     image: zedeus/nitter:latest
-    restart: unless-stopped
-    depends_on:
-      - redis
+    container_name: nitter
     ports:
-      - "8080:8080"
+      - "127.0.0.1:8080:8080" # Replace with "8080:8080" if you don't use a reverse proxy
     volumes:
       - ./nitter.conf:/src/nitter.conf
+    depends_on:
+      - nitter-redis
+    restart: unless-stopped
+
+  nitter-redis:
+    image: redis:6-alpine
+    container_name: nitter-redis
+    command: redis-server --save 60 1 --loglevel warning
+    volumes:
+      - nitter-redis:/data
+    restart: unless-stopped
+
 volumes:
   redis-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,4 @@ services:
     restart: unless-stopped
 
 volumes:
-  redis-data:
+  nitter-redis:

--- a/nitter.example.conf
+++ b/nitter.example.conf
@@ -10,7 +10,7 @@ hostname = "nitter.net"
 [Cache]
 listMinutes = 240  # how long to cache list info (not the tweets, so keep it high)
 rssMinutes = 10  # how long to cache rss queries
-redisHost = "localhost"  # Change to "redis" if using docker-compose
+redisHost = "localhost"  # Change to "nitter-redis" if using docker-compose
 redisPort = 6379
 redisPassword = ""
 redisConnections = 20  # connection pool size


### PR DESCRIPTION
- Add persistence to redis, following the official documentation ( https://hub.docker.com/_/redis see "start with persistent storage")
- Bind to localhost by default, so that the port isn't unnecessarily exposed
- Make nitter `depends-on` its redis container
- Rename the redis container so that it's nitter specific (edit the example config file accordingly)
- Enforce `container_name` (if you don't want that, feel free to remove those lines)