### PR TITLE
Utilize docker cache for less downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,13 @@ EXPOSE 8080
 
 RUN apk --no-cache add libsass-dev pcre
 
-COPY . /src/nitter
 WORKDIR /src/nitter
 
-RUN nimble build -y -d:danger -d:lto -d:strip \
+COPY nitter.nimble .
+RUN nimble install -y -d:strip
+
+COPY . .
+RUN nimble build -y -d:danger -d:lto \
     && nimble scss \
     && nimble md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY nitter.nimble .
 RUN nimble install -y -d:strip
 
 COPY . .
-RUN nimble build -y -d:danger -d:lto \
+RUN nimble build -d:danger -d:lto \
     && nimble scss \
     && nimble md
 


### PR DESCRIPTION
Hi. This PR takes advantage of the docker cache. Now, a system will not have to redownload the dependencies on every build.

I'm not very familiar with nimble build commands, so any comments or requested changes are very welcome.