### PR TITLE
Embed CSS tweak

### DIFF
--- a/src/sass/tweet/_base.scss
+++ b/src/sass/tweet/_base.scss
@@ -121,13 +121,17 @@
     background-color: var(--bg_panel);
 
     .tweet-content { 
-        font-size: 18px 
+        font-size: 18px;
     }
     
-    .tweet-body { 
+    .tweet-body {
         display: flex;
         flex-direction: column;
         max-height: calc(100vh - 0.75em * 2);
+    }
+
+    .card-image img {
+        height: auto;
     }
 }
 

--- a/src/views/general.nim
+++ b/src/views/general.nim
@@ -52,7 +52,7 @@ proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
   let opensearchUrl = getUrlPrefix(cfg) & "/opensearch"
 
   buildHtml(head):
-    link(rel="stylesheet", type="text/css", href="/css/style.css?v=16")
+    link(rel="stylesheet", type="text/css", href="/css/style.css?v=18")
     link(rel="stylesheet", type="text/css", href="/css/fontello.css?v=2")
 
     if theme.len > 0:


### PR DESCRIPTION
Attempt to fix https://github.com/zedeus/nitter/issues/537

It seems the image height being set to 100% caused some weird things with the footer in card tweets.

I tested it on a few different types of tweets and nothing seemed broken.

![image](https://user-images.githubusercontent.com/10339438/152653024-4cc10312-3548-4406-97ea-82bbdcaf916e.png)

I have no idea how to fix this background issue though.