### PR TITLE
Add new endpoint for original resolution images

### DIFF
--- a/src/routes/media.nim
+++ b/src/routes/media.nim
@@ -88,6 +88,20 @@ proc createMediaRouter*(cfg: Config) =
     get "/pic/?":
       resp Http404
 
+    get re"^\/pic\/orig\/(enc)?\/?(.+)":
+      var url = decoded(request, 1)
+      if "twimg.com" notin url:
+        url.insert(twimg)
+      if not url.startsWith(https):
+        url.insert(https)
+      url.add(":orig")
+
+      let uri = parseUri(url)
+      cond isTwitterUrl(uri) == true
+
+      let code = await proxyMedia(request, url)
+      check code
+
     get re"^\/pic\/(enc)?\/?(.+)":
       var url = decoded(request, 1)
       if "twimg.com" notin url:

--- a/src/routes/media.nim
+++ b/src/routes/media.nim
@@ -94,7 +94,7 @@ proc createMediaRouter*(cfg: Config) =
         url.insert(twimg)
       if not url.startsWith(https):
         url.insert(https)
-      url.add(":orig")
+      url.add("?name=orig")
 
       let uri = parseUri(url)
       cond isTwitterUrl(uri) == true

--- a/src/utils.nim
+++ b/src/utils.nim
@@ -42,6 +42,12 @@ proc getPicUrl*(link: string): string =
   else:
     &"/pic/{encodeUrl(link)}"
 
+proc getOrigPicUrl*(link: string): string =
+  if base64Media:
+    &"/pic/orig/enc/{encode(link, safe=true)}"
+  else:
+    &"/pic/orig/{encodeUrl(link)}"
+
 proc filterParams*(params: Table): seq[(string, string)] =
   for p in params.pairs():
     if p[1].len > 0 and p[0] notin nitterParams:

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -57,9 +57,9 @@ proc renderAlbum(tweet: Tweet): VNode =
           tdiv(class="attachment image"):
             let
               named = "name=" in photo
-              orig = if named: photo else: photo & "?name=orig"
-              small = if named: photo else: photo & "?name=small"
-            a(href=getPicUrl(orig), class="still-image", target="_blank"):
+              orig = photo
+              small = if named: photo else: photo & ":small"
+            a(href=getOrigPicUrl(orig), class="still-image", target="_blank"):
               genImg(small)
 
 proc isPlaybackEnabled(prefs: Prefs; video: Video): bool =

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -10,7 +10,7 @@ import general
 proc getSmallPic(url: string): string =
   result = url
   if "?" notin url and not url.endsWith("placeholder.png"):
-    result &= ":small"
+    result &= "?name=small"
   result = getPicUrl(result)
 
 proc renderMiniAvatar(user: User; prefs: Prefs): VNode =
@@ -58,7 +58,7 @@ proc renderAlbum(tweet: Tweet): VNode =
             let
               named = "name=" in photo
               orig = photo
-              small = if named: photo else: photo & ":small"
+              small = if named: photo else: photo & "?name=small"
             a(href=getOrigPicUrl(orig), class="still-image", target="_blank"):
               genImg(small)
 


### PR DESCRIPTION
This change is to work around the issue that chromium based browsers have handling the "name=orig" parameter appended to URLs. This parameter is needed to retrieve the full resolution image from twitter, but causes those browsers to fill in "jpg_name=orig" as the extension on the filename.

This change adds a new endpoint, "/pic/orig/<encoded media>". This new endpoint will internally fetch the URL with ":orig" appended on the end for the full res image. Externally, the endpoint will serve the image without the extra parameter to expose the real extension to the browser.

This new endpoint is used when rendering tweets with attached images. The old endpoint is still in place for all other proxied images, and for any legacy links.

I also updated the "?name=small" parameter to ":small" since that seems to be the new pattern for image sizing.

This should fix issue #458.