### PR TITLE
CSS Tweak to fix avatar issues when "hide tweet stats" is enabled

### DIFF
--- a/src/sass/tweet/_base.scss
+++ b/src/sass/tweet/_base.scss
@@ -98,8 +98,6 @@
 }
 
 .avatar {
-    position: absolute;
-
     &.round {
         border-radius: 50%;
     }

--- a/src/sass/tweet/_base.scss
+++ b/src/sass/tweet/_base.scss
@@ -121,11 +121,22 @@
     .tweet-content { 
         font-size: 18px;
     }
+    
+    .tweet-body {
+        display: flex;
+        flex-direction: column;
+        max-height: calc(100vh - 0.75em * 2);
+    }
 
     .card-image img {
         height: auto;
     }
+    
+    .avatar {
+        position: absolute;
+    }
 }
+
 
 .attribution {
     display: flex;

--- a/src/sass/tweet/_base.scss
+++ b/src/sass/tweet/_base.scss
@@ -121,12 +121,6 @@
     .tweet-content { 
         font-size: 18px;
     }
-    
-    .tweet-body {
-        display: flex;
-        flex-direction: column;
-        max-height: calc(100vh - 0.75em * 2);
-    }
 
     .card-image img {
         height: auto;


### PR DESCRIPTION
When using the "hide tweet stats" option, single-line tweets would cut off too early.
![image](https://user-images.githubusercontent.com/36683489/154821495-66d3ab4d-8da0-4381-94c1-f4d1a866c360.png)
Removing the position: absolute tag from the avatar fixes this, and from browsing around on both Pale Moon and Chromium with this change, it does not visually inhibit any other scenario.
![image](https://user-images.githubusercontent.com/36683489/154821526-3d1f8d27-88b1-4ed6-b7ab-1fffd1fa8b23.png)