### PR TITLE
Fix bio hashtag

### DIFF
--- a/src/experimental/parser/user.nim
+++ b/src/experimental/parser/user.nim
@@ -8,7 +8,7 @@ let
   unRegex = re.re"(^|[^A-z0-9-_./?])@([A-z0-9_]{1,15})"
   unReplace = "$1<a href=\"/$2\">@$2</a>"
 
-  htRegex = nre.re"(*U)(^|[^\w-_./?])([#＃$])([\w_]+)"
+  htRegex = nre.re"""(*U)(^|[^\w-_.?])([#＃$])([\w_]*+)(?!</a>|">|#)"""
   htReplace = "$1<a href=\"/search?q=%23$3\">$2$3</a>"
 
 proc expandUserEntities(user: var User; raw: RawUser) =

--- a/src/experimental/parser/user.nim
+++ b/src/experimental/parser/user.nim
@@ -1,14 +1,14 @@
-import std/[algorithm, unicode, re, strutils, strformat, options]
+import std/[algorithm, unicode, re, strutils, strformat, options, nre]
 import jsony
 import utils, slices
 import ../types/user as userType
 from ../../types import User, Error
 
 let
-  unRegex = re"(^|[^A-z0-9-_./?])@([A-z0-9_]{1,15})"
+  unRegex = re.re"(^|[^A-z0-9-_./?])@([A-z0-9_]{1,15})"
   unReplace = "$1<a href=\"/$2\">@$2</a>"
 
-  htRegex = re"(^|[^\w-_./?])([#＃$])([\w_]+)"
+  htRegex = nre.re"(*U)(^|[^\w-_./?])([#＃$])([\w_]+)"
   htReplace = "$1<a href=\"/search?q=%23$3\">$2$3</a>"
 
 proc expandUserEntities(user: var User; raw: RawUser) =
@@ -29,7 +29,7 @@ proc expandUserEntities(user: var User; raw: RawUser) =
 
   user.bio = orig.replacedWith(replacements, 0 .. orig.len)
                  .replacef(unRegex, unReplace)
-                 .replacef(htRegex, htReplace)
+                 .replace(htRegex, htReplace)
 
 proc getBanner(user: RawUser): string =
   if user.profileBannerUrl.len > 0:


### PR DESCRIPTION
1. The first commit fix #521 and https://github.com/zedeus/nitter/issues/530#issuecomment-1024725110

    For #529 the modification is correct but in wrong file. should modify `src/experimental/parser/user.nim`.

    For https://github.com/zedeus/nitter/issues/530#issuecomment-1024725110  we use std/nre to support Unicode hashtag

    When using nre with `(*U)` , PR #529 is not necessary since regex pattern is generated correctly to treat  `＃` as a single word. and this pattern will also match all Unicode in hashtags.

2. The second commit fix #530 
  remove `/` in htRegex and add negative lookahead to guarantee that URL fragments like `<a href="http://example.com/#testabcd">example.com/#testabcd</a> ` in bio will not be parsed to hashtag .
 also make `#aaa#bbb` behaves the same as twitter which is that these two words are not parsed as hashtag.