### PR TITLE
Prefer mp4 to m3u8 for Video Playback (for no-js, no-proxy)

### DIFF
--- a/src/parser.nim
+++ b/src/parser.nim
@@ -76,8 +76,8 @@ proc parseVideo(js: JsonNode): Video =
     views: js{"ext", "mediaStats", "r", "ok", "viewCount"}.getStr,
     available: js{"ext_media_availability", "status"}.getStr == "available",
     title: js{"ext_alt_text"}.getStr,
-    durationMs: js{"video_info", "duration_millis"}.getInt
-    # playbackType: mp4
+    durationMs: js{"video_info", "duration_millis"}.getInt,
+    playbackType: mp4
   )
 
   with title, js{"additional_media_info", "title"}:

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -100,7 +100,7 @@ proc renderVideo*(video: Video; prefs: Prefs; path: string): VNode =
           renderVideoDisabled(video, path)
         else:
           let vid = video.variants.filterIt(it.contentType == video.playbackType)
-          let source = getVidUrl(vid[0].url)
+          let source = if prefs.proxyVideos: getVidUrl(vid[0].url) else: vid[0].url
           case video.playbackType
           of mp4:
             if prefs.muteVideos:


### PR DESCRIPTION
This allows video playback without Javascript and when proxying videos
is turned off.

---

I'm not sure why `playbackType: mp4` was commented out; the default value is m3u8, not mp4, so keeping it as a comment is quite misleading.

Right now, this just takes the first (`[0]`) mp4 url. The mp4 URLs actually contain the resolution of the video file, so it would be good to take the highest quality one. AFAICT they aren't always sorted best-to-worst.