### PR TITLE
Implement healthcheck on nitter and redis

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,11 @@ services:
     depends_on:
       - nitter-redis
     restart: unless-stopped
+    healthcheck:
+      test: wget -nv --tries=1 --spider http://127.0.0.1:8080/Jack/status/20 || exit 1
+      interval: 30s
+      timeout: 5s
+      retries: 2
 
   nitter-redis:
     image: redis:6-alpine
@@ -20,6 +25,11 @@ services:
     volumes:
       - nitter-redis:/data
     restart: unless-stopped
+    healthcheck:
+      test: redis-cli ping
+      interval: 30s
+      timeout: 5s
+      retries: 2
 
 volumes:
   nitter-redis:


### PR DESCRIPTION
This will implement a basic healthcheck in the docker-compose file for both Nitter and Redis. The healthcheck can be used by administrators to easily spot potential problems with a running container. It can also be used to automatically restart or recreate unhealthy containers (eg. via willfarrell/docker-autoheal) should the administrator desire to do so.