### PR TITLE
Dockerfile: Move EXPOSE outside the builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM nimlang/nim:1.6.2-alpine-regular as nim
 LABEL maintainer="setenforce@protonmail.com"
-EXPOSE 8080
 
 RUN apk --no-cache add libsass-dev pcre
 
@@ -20,4 +19,5 @@ RUN apk --no-cache add pcre
 COPY --from=nim /src/nitter/nitter ./
 COPY --from=nim /src/nitter/nitter.example.conf ./nitter.conf
 COPY --from=nim /src/nitter/public ./public
+EXPOSE 8080
 CMD ./nitter


### PR DESCRIPTION
In multistage builds, `EXPOSE` needs to be mentioned in the stage it applies to. Right now, we’re exposing 8080 from the builder, not the runtime.

You can tell that `EXPOSE 8080` isn’t being propagated into the final images:

```
$ docker inspect nitter:latest | grep 8080
$ docker inspect nitter:nopdotcom | grep 8080
                "8080/tcp": {}
$
```