### PR TITLE
Docker: add ca-certificates to runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN nimble build -d:danger -d:lto -d:strip \
 
 FROM alpine:latest
 WORKDIR /src/
-RUN apk --no-cache add pcre
+RUN apk --no-cache add pcre ca-certificates
 COPY --from=nim /src/nitter/nitter ./
 COPY --from=nim /src/nitter/nitter.example.conf ./nitter.conf
 COPY --from=nim /src/nitter/public ./public


### PR DESCRIPTION
Current Alpine doesn't ship with the "well-known” CA certificates. Without them present, outbound HTTPS or TLS connections aren't even initiated, leading to this at startup:

```
fetching token failed: No SSL/TLS CA certificates found.
```

This adds `ca-certificates` to the runtime image.