### PR TITLE
Make tweet-content inline-block to get direction

### DIFF
--- a/src/sass/tweet/_base.scss
+++ b/src/sass/tweet/_base.scss
@@ -20,7 +20,7 @@
     font-family: $font_3;
     line-height: 1.3em;
     pointer-events: all;
-    display: inline;
+    display: inline-block;
 }
 
 .tweet-bidi {


### PR DESCRIPTION
Currently the body of tweet has `display: inline;` style. This, prevents getting proper direction and alignment when the language doesn't follow the global language in terms of direction (LTR/RTL).

![image](https://user-images.githubusercontent.com/11241315/162582343-1687bd7b-a9a0-467a-b55a-ac363bf03f06.png)

After this change (which shouldn't be breaking change), the text gets rendered in correct direction and alignment.