### PR TITLE
Video embeds

### DIFF
--- a/src/routes/status.nim
+++ b/src/routes/status.nim
@@ -46,8 +46,10 @@ proc createStatusRouter*(cfg: Config) =
         video = ""
 
       if conv.tweet.video.isSome():
-        images = @[get(conv.tweet.video).thumb]
-        video = getVideoEmbed(cfg, conv.tweet.id)
+        let vid = get(conv.tweet.video)
+        images = @[vid.thumb]
+        let vids = vid.variants.filterIt(it.contentType == VideoType.mp4)
+        video = getVidUrl(vids[0].url)
       elif conv.tweet.gif.isSome():
         images = @[get(conv.tweet.gif).thumb]
         video = getPicUrl(get(conv.tweet.gif).url)

--- a/src/views/general.nim
+++ b/src/views/general.nim
@@ -109,13 +109,17 @@ proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
 
       if rss.len > 0:
         meta(property="twitter:card", content="summary")
+      elif video.len > 0:
+        meta(property="twitter:card", content="player")
       else:
         meta(property="twitter:card", content="summary_large_image")
 
     if video.len > 0:
       meta(property="og:video:url", content=video)
       meta(property="og:video:secure_url", content=video)
-      meta(property="og:video:type", content="text/html")
+      meta(property="og:video:type", content="video/mp4")
+      meta(name="twitter:player:stream", content=video)
+      meta(name="twitter:player:stream:content_type", content="video/mp4")
 
     # this is last so images are also preloaded
     # if this is done earlier, Chrome only preloads one image for some reason


### PR DESCRIPTION
This was made in response to TwitFix/fxtwitter shutting down.

It uses the twitter:player:* meta tags with mp4 video links.

The big downside right now is that descriptions won't be embedded on videos. TwitFix worked around this with yet another embed tag called [oEmbed](https://oembed.com/).

sample
![image](https://user-images.githubusercontent.com/22580720/168658769-8650e94c-2ecc-45b0-b681-279d656d598b.png)
