### PR TITLE
Block search engines via robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Prevents instances from being rate limited due to being senselessly
crawled by search engines. Since there is no reason to index Nitter
instances, simply block all robots. Notably, this does *not* affect link
previews (e.g. in various chat software).

Invidious and Bibliogram do already ship a robots.txt by default and I think
it's a good thing for Nitter to do the same, looking at #305, #470 and that
rel=canonical (#472) seems to do nothing.
