### PR TITLE
Add widgets script

### DIFF
--- a/public/js/iframeResize.js
+++ b/public/js/iframeResize.js
@@ -1,0 +1,9 @@
+window.addEventListener('load', (event) => {
+    window.parent.postMessage(["resizeIframe",
+    {
+        "url": document.baseURI,
+        "w": document.body.offsetWidth,
+        "h": document.body.offsetHeight
+    }
+    ], "*");
+})

--- a/public/js/widgets.js
+++ b/public/js/widgets.js
@@ -1,0 +1,33 @@
+let iframeMap = {}
+
+const instance = 'https://nitter.net'
+const tweet_regex = /^https?:\/\/twitter\.com\/[^/]+\/status\/(\d+)\??/
+const blockquotes = document.querySelectorAll('blockquote.twitter-tweet > a')
+for (const blockquote of blockquotes) {
+  const link = blockquote.href
+  const id = tweet_regex.exec(link)[1]
+  const embed = document.createElement('iframe')
+  const url = `${instance}/i/status/${id}/embed`
+  embed.src = url
+  embed.style = 'width:100%;height:600px'
+  embed.loading = 'lazy'
+  blockquote.parentNode.replaceWith(embed)
+  if (iframeMap[url]) {
+    iframeMap[url].push(embed)
+  } else {
+    iframeMap[url] = [embed]
+  }
+}
+
+window.addEventListener('message', function(e) {
+  if (e.origin != instance || e.data[0] != 'resizeIframe')
+    return
+  
+  const data = e.data[1];
+  const height = data['h']
+  if (height == 0)
+    return
+  for (const embed of iframeMap[data['url']]) {
+    embed.style.height = `${height}px`
+  }
+}, false);

--- a/src/views/embed.nim
+++ b/src/views/embed.nim
@@ -13,7 +13,7 @@ proc renderVideoEmbed*(tweet: Tweet; cfg: Config; req: Request): string =
   let vidUrl = getVideoEmbed(cfg, tweet.id)
   let prefs = Prefs(hlsPlayback: true)
   let node = buildHtml(html(lang="en")):
-    renderHead(prefs, cfg, req, video=vidUrl, images=(@[thumb]))
+    renderHead(prefs, cfg, req, video=vidUrl, images=(@[thumb]), baseTarget="_parent")
 
     body:
       tdiv(class="embed-video"):

--- a/src/views/general.nim
+++ b/src/views/general.nim
@@ -38,7 +38,7 @@ proc renderNavbar(cfg: Config; req: Request; rss, canonical: string): VNode =
 
 proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
                  video=""; images: seq[string] = @[]; banner=""; ogTitle="";
-                 rss=""; canonical=""): VNode =
+                 rss=""; canonical=""; baseTarget=""): VNode =
   var theme = prefs.theme.toTheme
   if "theme" in req.params:
     theme = req.params["theme"].toTheme
@@ -121,6 +121,9 @@ proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
     # if this is done earlier, Chrome only preloads one image for some reason
     link(rel="preload", type="font/woff2", `as`="font",
          href="/fonts/fontello.woff2?21002321", crossorigin="anonymous")
+
+    if baseTarget.len > 0:
+      base(target=baseTarget)
 
 proc renderMain*(body: VNode; req: Request; cfg: Config; prefs=defaultPrefs;
                  titleText=""; desc=""; ogTitle=""; rss=""; video="";

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -374,5 +374,6 @@ proc renderTweetEmbed*(tweet: Tweet; path: string; prefs: Prefs; cfg: Config; re
     body:
       tdiv(class="tweet-embed"):
         renderTweet(tweet, prefs, path, mainTweet=true)
+      script(src="/js/iframeResize.js", `defer`="")
 
   result = doctype & $node

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -369,7 +369,7 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
 
 proc renderTweetEmbed*(tweet: Tweet; path: string; prefs: Prefs; cfg: Config; req: Request): string =
   let node = buildHtml(html(lang="en")):
-    renderHead(prefs, cfg, req)
+    renderHead(prefs, cfg, req, baseTarget="_parent")
 
     body:
       tdiv(class="tweet-embed"):


### PR DESCRIPTION
This hosts a widgets.js iframe replacement at `/js/widgets.js`. A redirector has to point `https://platform.twitter.com/widgets.js` there.

Enables resizing of iframe by parents listening on `resizeIframe`.
This aids in closing #586.

Instances should update their host configs to allow being embedded in iframes. The wiki should be updated too.