### PR TITLE
Add redirect for `thread` links

### DIFF
--- a/src/routes/status.nim
+++ b/src/routes/status.nim
@@ -72,3 +72,6 @@ proc createStatusRouter*(cfg: Config) =
 
     get "/i/web/status/@id":
       redirect("/i/status/" & @"id")
+      
+    get "/@name/thread/@id/?":
+      redirect("/$1/status/$2" % [@"name", @"id"])


### PR DESCRIPTION
This matches Twitter's behavior. Example: https://twitter.com/jonhoo/thread/1539661689880137728