### PR TITLE
Reintroduce space around delimiter in html title for better readability

### DIFF
--- a/src/views/general.nim
+++ b/src/views/general.nim
@@ -42,7 +42,7 @@ proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
   var theme = prefs.theme.toTheme
   if "theme" in req.params:
     theme = req.params["theme"].toTheme
-    
+
   let ogType =
     if video.len > 0: "video"
     elif rss.len > 0: "object"
@@ -81,7 +81,7 @@ proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
 
     title:
       if titleText.len > 0:
-        text &"{titleText}|{cfg.title}"
+        text &"{titleText} | {cfg.title}"
       else:
         text cfg.title
 


### PR DESCRIPTION
The `|` delimiter was surrounded by spaces before 21e8f04fa47cbef5332210eb650ef7819cf9bca8 which I believe was removed by accident. The spaces allow the text to break into a new line in certain situations and so on which improves readability. 