### PR TITLE
add `threads:off` to the config file

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,5 +1,6 @@
 --define:ssl
 --define:useStdLib
+--threads:off
 
 # workaround httpbeast file upload bug
 --assertions:off


### PR DESCRIPTION
Hello, Nim v2 is going to make `threads:on` default, which was discussed here: https://github.com/nim-lang/RFCs/issues/361 and listed as the roadmap for 2.0: https://github.com/nim-lang/RFCs/issues/437

I made a PR (https://github.com/nim-lang/Nim/pull/19368) to enable threads, nitter gives in CI

```
  /Users/runner/work/Nim/Nim/pkgstemp/nitter/src/routes/preferences.nim(19, 10) template/generic instantiation of `router` from here
  /Users/runner/.nimble/pkgs/jester-0.5.0/jester.nim(1304, 35) template/generic instantiation of `async` from here
  /Users/runner/work/Nim/Nim/lib/pure/asyncmacro.nim(210, 31) Error: 'preferencesIter' is not GC-safe as it accesses 'defaultPrefs' which is a global using GC'ed memory
```

So I add `threads:off` to the config file.