### PR TITLE
fix #680: make video control bar fit parent div

### DIFF
--- a/src/sass/tweet/video.scss
+++ b/src/sass/tweet/video.scss
@@ -3,7 +3,7 @@
 
 video {
     max-height: 100%;
-    max-width: 100%;
+    width: 100%;
 }
 
 .gallery-video {


### PR DESCRIPTION
Now
Chrome Desktop
![Screenshot from 2022-08-12 09-14-37](https://user-images.githubusercontent.com/2900871/184314457-9fbaec52-3508-4fc8-bc0e-62856203aea4.png)

Chrome Mobile
![Screenshot from 2022-08-12 09-15-33](https://user-images.githubusercontent.com/2900871/184314472-93f9d482-4645-4dd7-8e6d-3370bb47ce27.png)

Firefox Desktop
![ffdesk](https://user-images.githubusercontent.com/2900871/184314526-cb379540-e1df-4556-af2d-a6b43bb2ae01.PNG)

Firefox Mobile
![ffmob](https://user-images.githubusercontent.com/2900871/184314548-c63b231f-e886-4422-ad9e-6de1200c64fa.PNG)

