### PR TITLE
bump karax version

### DIFF
--- a/nitter.nimble
+++ b/nitter.nimble
@@ -12,7 +12,7 @@ bin           = @["nitter"]
 
 requires "nim >= 1.4.8"
 requires "jester >= 0.5.0"
-requires "karax#5498909"
+requires "karax#6abcb77"
 requires "sass#e683aa1"
 requires "nimcrypto#a5742a9"
 requires "markdown#a661c26"


### PR DESCRIPTION
My bad, but the karax dep needs to include https://github.com/karaxnim/karax/pull/230 (patches for ARC/ORC) too. 