### PR TITLE
views/tweet: add .author-$user, .retweet-$user to classlist for adblock

### DIFF
--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -295,6 +295,7 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
     divClass = "thread-last " & class
 
   if not tweet.available:
+    divClass &= " author-" & tweet.user.username
     return buildHtml(tdiv(class=divClass & "unavailable timeline-item")):
       tdiv(class="unavailable-box"):
         if tweet.tombstone.len > 0:
@@ -313,6 +314,9 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
   if tweet.retweet.isSome:
     tweet = tweet.retweet.get
     retweet = fullTweet.user.fullname
+    divClass &= " retweet-" & retweet
+
+  divClass &= " author-" & tweet.user.fullname
 
   buildHtml(tdiv(class=("timeline-item " & divClass))):
     if not mainTweet:


### PR DESCRIPTION
Please be aware that I literally just installed nim, and that (although this change compiles) I haven't tried actually running this code. I don't even expect this change to be adopted (I don't even use ad-blockers myself), but rather for this to start a conversation on how blocking people on nitter could be implemented (if it should even be supported at all).

The main impetus for this is that I wish to stop being counted as a twitter "daily active user," and yet open links people choose to share with me. Unfortunately, I still lack the mental fortitude not to check out the replies, and regret it immediately afterwards.

Server-side blocking would require an account infrastructure that doesn't exist, or perhaps sending the blocklist as a cookie on every request (at 4,096 chars per cookie, that'd be.... a _lot_ of cookies). Native client-side blocking would require being able to run javascript, something that AFAICT nitter politely asks for in order to enable video playback. This commit relies on the capabilities of existing ad-blocking extensions: just add `.retweet-$user` and `.author-$user` to your blocklist. This mechanism is unsatisfactory in more than one way (mobile, desktop Chrome) but it's 🌈 better than nothing ✨