### PR TITLE
Increase @media max-width from 700px to 800px

### DIFF
--- a/src/sass/profile/_base.scss
+++ b/src/sass/profile/_base.scss
@@ -54,10 +54,10 @@
     }
 }
 
-@media(max-width: 700px) {
+@media(max-width: 800px) {
     .profile-tabs {
         width: 100vw;
-        max-width: 600px;
+        max-width: 95%;
 
         .timeline-container {
             width: 100% !important;

--- a/src/sass/profile/card.scss
+++ b/src/sass/profile/card.scss
@@ -109,7 +109,7 @@
     color: var(--profile_stat);
 }
 
-@media(max-width: 700px) {
+@media(max-width: 800px) {
     .profile-card-info {
         display: flex;
     }

--- a/src/sass/profile/photo-rail.scss
+++ b/src/sass/profile/photo-rail.scss
@@ -60,7 +60,7 @@
     padding-bottom: 12px;
 }
 
-@media(max-width: 700px) {
+@media(max-width: 800px) {
     .photo-rail-header {
         display: none;
     }


### PR DESCRIPTION
Hello :wave: 

Just a small PR to increase the `max-width` parameter of `@media` from 700px to 800px, to increase readability mostly on smartphones in landscape mode. It probably solves in a way https://github.com/zedeus/nitter/issues/591.

## Current behavior

I've noticed that on devices with small width (but > 700px, like some smartphones in landscape mode), the profile bar stays on the side, taking 30% of the screen.

When the width is <= 700px, then the sidebar is moved to the top.

By moving the profile bar from the side to the top, it allows a better readability on these devices. The issue is that 700px is now probably too low for most of the smartphones; new ones like iPhones, Galaxy, etc. have at least a 800px width.

## Update

To change that behavior, I've updated the max-width value from 700px to 800px. Also, instead of having a max width at 600px when `@media(max-width: 800px)`, I've updated it to 95% of the screen.

## Values chosen

I've chosen 800px because most of the smartphones in landscape mode have now a width > 700px. But newer models have widths even greater than 800px (for example, 812px for iPhone 11 Pro, and even greater for new iPhones). So actually, the 800px could even be increased to 900px to my opinion.

Also, increasing the max width to 95% is more readable to me; but it's just my preference.