### PR TITLE
Additional hardening for Docker-Compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,12 @@ services:
       interval: 30s
       timeout: 5s
       retries: 2
+    user: "998:998"
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
   nitter-redis:
     image: redis:6-alpine
@@ -30,6 +36,12 @@ services:
       interval: 30s
       timeout: 5s
       retries: 2
+    user: "999:1000"
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
 
 volumes:
   nitter-redis:


### PR DESCRIPTION
Nitter runs as root inside of the container, which is unnecessary, so I just force it to run as 998:998. Ideally, you can make it run as an unprivileged user inside of the Dockerfile itself, but it's still good practice imo to force the container to run as an unprivileged user via docker-compose.

Redis already runs as an unprivileged user (998:1000) inside of the container, but I also force the container to run as said user in the docker-compose.yml file.

read_only: true is set as there is no reason for there to be any write to either of these containers outside of the bind mounted directories.

no-new-privileges:true and cap drop all are set because there is no reason for these containers to use capabilities or elevate privileges.
