### PR TITLE
Change :ro to :Z

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "127.0.0.1:8080:8080" # Replace with "8080:8080" if you don't use a reverse proxy
     volumes:
-      - ./nitter.conf:/src/nitter.conf:Z
+      - ./nitter.conf:/src/nitter.conf:Z,ro
     depends_on:
       - nitter-redis
     restart: unless-stopped


### PR DESCRIPTION
:Z is needed for SELinux systems. The side effect of setting :Z is that the config will be writable inside of the container, but I do not think it matters too much.