### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY nitter.nimble .
 RUN nimble install -y --depsOnly
 
 COPY . .
-RUN nimble build -d:danger -d:lto -d:strip \
+RUN nimble build -d:danger -d:lto -d:strip -d:nimDebugDlOpen \
     && nimble scss \
     && nimble md
 


### PR DESCRIPTION
running the container gave me the following error:

could not load: libcrypto.so(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|) (compile with -d:nimDebugDlOpen for more information)

This adds the requested library.