### PR TITLE
Bump zippy dependency (fixes #750 arm64 build error)

### DIFF
--- a/nitter.nimble
+++ b/nitter.nimble
@@ -20,7 +20,7 @@ requires "packedjson#9e6fbb6"
 requires "supersnappy#6c94198"
 requires "redpool#8b7c1db"
 requires "https://github.com/zedeus/redis#d0a0e6f"
-requires "zippy#61922b9"
+requires "zippy#88a5a5a"
 requires "flatty#9f885d7"
 requires "jsony#d0e69bd"
 


### PR DESCRIPTION
https://github.com/guzba/zippy/commit/e67b880fed12ff095bffdee8d74ee4bf34570151 fixes a type mismatch on arm64 builds.