### PR TITLE
Build and push ARM64 docker image

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-      - name: Build and push
+      - name: Build and push AMD64 Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
@@ -36,3 +36,11 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: zedeus/nitter:latest,zedeus/nitter:${{ github.sha }}
+      - name: Build and push ARM64 Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.arm64
+          platforms: linux/arm64
+          push: true
+          tags: zedeus/nitter:latest-arm64,zedeus/nitter:${{ github.sha }}-arm64


### PR DESCRIPTION
Follow up of https://github.com/zedeus/nitter/pull/762

This will create a separate docker image tag for ARM64.