### PR TITLE
Add openssl1.1-compat to Dockerfile.arm64

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -15,7 +15,7 @@ RUN nimble build -d:danger -d:lto -d:strip \
 
 FROM alpine:3.17
 WORKDIR /src/
-RUN apk --no-cache add pcre ca-certificates
+RUN apk --no-cache add ca-certificates pcre openssl1.1-compat
 COPY --from=nim /src/nitter/nitter ./
 COPY --from=nim /src/nitter/nitter.example.conf ./nitter.conf
 COPY --from=nim /src/nitter/public ./public


### PR DESCRIPTION
This is a follow up to #762.

It looks like the openssl1.1-compat package also needs to be added now in order for Nitter to work correctly. Without it, the image does still build successfully, however it produces an error in the container logs about libcrypto.so missing:

```
nitter        | could not load: libcrypto.so(.1.1|.1.0.2|.1.0.1|.1.0.0|.0.9.9|.0.9.8|.48|.47|.46|.45|.44|.43|.41|.39|.38|.10|)
nitter        | (compile with -d:nimDebugDlOpen for more information)
```

Adding openssl1.1-compat to the second container does resolve the issue.

I apologize for the need for this follow up, back when I tested the initial version of the image, it did function correctly, but after making the requested changes in #762, you merged it so fast that I haven't yet finished the build to see if it actually works. :smile:

As for why it has worked back then and not now, maybe it has to do with the recent OpenSSL vulnerabilities.