### PR TITLE
parse long tweets

### DIFF
--- a/src/consts.nim
+++ b/src/consts.nim
@@ -85,7 +85,7 @@ const
   "responsive_web_edit_tweet_api_enabled": false,
   "tweetypie_unmention_optimization_enabled": false,
   "vibe_api_enabled": false,
-  "longform_notetweets_consumption_enabled": false,
+  "longform_notetweets_consumption_enabled": true,
   "responsive_web_text_conversations_enabled": false,
   "responsive_web_enhance_cards_enabled": false,
   "interactive_text_enabled": false

--- a/src/parser.nim
+++ b/src/parser.nim
@@ -385,6 +385,10 @@ proc parseGraphTweet(js: JsonNode): Tweet =
   result = parseTweet(js{"legacy"}, jsCard)
   result.user = parseUser(js{"core", "user_results", "result", "legacy"})
 
+  var note_tweet = js{"note_tweet", "note_tweet_results", "result"}
+  if note_tweet.kind != JNull:
+    result.expandNoteTweetEntities(note_tweet)
+
   if result.quote.isSome:
     result.quote = some(parseGraphTweet(js{"quoted_status_result", "result"}))
 

--- a/src/parser.nim
+++ b/src/parser.nim
@@ -385,9 +385,8 @@ proc parseGraphTweet(js: JsonNode): Tweet =
   result = parseTweet(js{"legacy"}, jsCard)
   result.user = parseUser(js{"core", "user_results", "result", "legacy"})
 
-  var note_tweet = js{"note_tweet", "note_tweet_results", "result"}
-  if note_tweet.kind != JNull:
-    result.expandNoteTweetEntities(note_tweet)
+  with noteTweet, js{"note_tweet", "note_tweet_results", "result"}:
+    result.expandNoteTweetEntities(noteTweet)
 
   if result.quote.isSome:
     result.quote = some(parseGraphTweet(js{"quoted_status_result", "result"}))


### PR DESCRIPTION
This enables the feature `longform_notetweets_consumption_enabled` in graphql and parses the note tweets if they are available.
Sadly the nature of twitters horrendous API still requires the old routine to parse the "legacy" text to get the correct replies which are not obtainable in `note_tweet`.
<details>
<img src="https://user-images.githubusercontent.com/22580720/222010817-77501a75-026d-4e71-873e-97f114216112.png"/>
<img src="https://user-images.githubusercontent.com/22580720/222010997-b4013b41-c7e3-4983-9529-010ec70f4f86.png"/>

</details>