### PR TITLE
Escape special characters in long tweets

### DIFF
--- a/src/parserutils.nim
+++ b/src/parserutils.nim
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-only
-import std/[strutils, times, macros, htmlgen, options, algorithm, re]
+import std/[strutils, times, macros, htmlgen, options, algorithm, re, xmltree]
 import std/unicode except strip
 import packedjson
 import types, utils, formatters
@@ -297,7 +297,7 @@ proc expandTweetEntities*(tweet: Tweet; js: JsonNode) =
 proc expandNoteTweetEntities*(tweet: Tweet; js: JsonNode) =
   let
     entities = ? js{"entity_set"}
-    text = js{"text"}.getStr
+    text = xmltree.escape(js{"text"}.getStr)
     textSlice = 0..text.runeLen
 
   tweet.expandTextEntities(entities, text, textSlice)


### PR DESCRIPTION
It seems that although the legacy API pre-escapes special characters (`<`, `>`, and `&`), the newer GraphQL API, which is used for long tweets, does not.