### PR TITLE
Add non-root user to arm dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ RUN nimble build -d:danger -d:lto -d:strip \
 
 FROM alpine:latest
 WORKDIR /src/
-RUN apk --no-cache add pcre ca-certificates
+RUN apk --no-cache add pcre ca-certificates && \
+    adduser -h /src/ -D -s /bin/sh nitter
 COPY --from=nim /src/nitter/nitter ./
-COPY --from=nim /src/nitter/nitter.example.conf ./nitter.conf
+COPY --from=nim --chown=nitter:nitter /src/nitter/nitter.example.conf ./nitter.conf
 COPY --from=nim /src/nitter/public ./public
 EXPOSE 8080
-RUN adduser -h /src/ -D -s /bin/sh nitter
 USER nitter
 CMD ./nitter

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -15,9 +15,11 @@ RUN nimble build -d:danger -d:lto -d:strip \
 
 FROM alpine:3.17
 WORKDIR /src/
-RUN apk --no-cache add ca-certificates pcre openssl1.1-compat
+RUN apk --no-cache add ca-certificates pcre openssl1.1-compat && \
+    adduser -h /src/ -D -s /bin/sh nitter
 COPY --from=nim /src/nitter/nitter ./
-COPY --from=nim /src/nitter/nitter.example.conf ./nitter.conf
+COPY --from=nim --chown=nitter:nitter /src/nitter/nitter.example.conf ./nitter.conf
 COPY --from=nim /src/nitter/public ./public
 EXPOSE 8080
+USER nitter
 CMD ./nitter


### PR DESCRIPTION
- Arm Dockerfile missing nitter user. 
- Removed one unnecessary layer in final image
- nitter.conf is now editable by the container user