### PR TITLE
fixed bug that caused some retweets to be rendered incorrectly

### DIFF
--- a/src/parser.nim
+++ b/src/parser.nim
@@ -230,8 +230,11 @@ proc parseTweet(js: JsonNode; jsCard: JsonNode = newJNull()): Tweet =
   # graphql
   with rt, js{"retweeted_status_result", "result"}:
     # needed due to weird edgecase where the actual tweet data isn't included
-    if "legacy" in rt:
-      result.retweet = some parseGraphTweet(rt)
+    var rt_tweet = rt
+    if "tweet" in rt:
+      rt_tweet = rt{"tweet"}
+    if "legacy" in rt_tweet:
+      result.retweet = some parseGraphTweet(rt_tweet)
       return
 
   if jsCard.kind != JNull:


### PR DESCRIPTION
Some retweets have been truncated and displayed as "regular tweets" from the retweeter instead of a proper retweet.
In these cases the tweet message started with "RT @original_tweeter_handle".

Apparently there is a "tweet" element between the "legacy" and the "retweeted_status_result"."result" element sometimes. The "result" has the "__typename" "TweetWithVisibilityResults" when that is the case. Otherwise "__typename" is just "Tweet".

This might only be related to authentication based instances as this is where I have observed this kind of behaviors. But it might not be limited to it.

It looks like this kind of behaviour has already been observed and handled in a [different spot in the nitter code base](https://github.com/zedeus/nitter/blob/38985af6ed30f050201b15425cdac0dc2e286b6d/src/parser.nim#L393) but unfortunately this check does not catch this case yet.