### PR TITLE
Add data-tweet-id attribute to tweet timeline-item and quote elements

### DIFF
--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -232,7 +232,7 @@ proc renderQuote(quote: Tweet; prefs: Prefs; path: string): VNode =
         else:
           text "This tweet is unavailable"
 
-  buildHtml(tdiv(class="quote quote-big")):
+  buildHtml(tdiv(class="quote quote-big", "data-tweet-id" = $quote.id)):
     a(class="quote-link", href=getLink(quote))
 
     tdiv(class="tweet-name-row"):
@@ -277,7 +277,7 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
     divClass = "thread-last " & class
 
   if not tweet.available:
-    return buildHtml(tdiv(class=divClass & "unavailable timeline-item")):
+    return buildHtml(tdiv(class=divClass & "unavailable timeline-item", "data-tweet-id" = $tweet.id)):
       tdiv(class="unavailable-box"):
         if tweet.tombstone.len > 0:
           text tweet.tombstone
@@ -299,7 +299,7 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
     tweet = tweet.retweet.get
     retweet = fullTweet.user.fullname
 
-  buildHtml(tdiv(class=("timeline-item " & divClass))):
+  buildHtml(tdiv(class=("timeline-item " & divClass), "data-tweet-id" = $tweet.id)):
     if not mainTweet:
       a(class="tweet-link", href=getLink(tweet))
 


### PR DESCRIPTION
This adds a `data-tweet-id` attribute to the container element of tweets and quotes, including unavailable tweets. This helps when programmatically parsing nitter timelines since there isn't a proper API yet. Especially important is adding the tweet ID to unavailable tweets. I use nitter to grab timelines and then a separate tool to download the individual tweets that supports age-restricted tweets.