### PR TITLE
Add support for displaying Community Notes

### DIFF
--- a/src/consts.nim
+++ b/src/consts.nim
@@ -4,8 +4,11 @@ import uri, sequtils, strutils
 const
   consumerKey* = "3nVuSoBZnx6U4vzUxf5w"
   consumerSecret* = "Bcs59EFbbsdF6Sl9Ng71smgStWEGwXXKSjYvPVt7qys"
+  bearerToken* = "AAAAAAAAAAAAAAAAAAAAANRILgAAAAAAnNwIzUejRCOuH5E6I8xnZz4puTs%3D1Zv7ttfk8LF81IUq16cHjhLTvJu4FA33AGWWjCpTnA"
 
   api = parseUri("https://api.twitter.com")
+  # This is the API accessed by the browser, which is different from the developer API
+  browserApi = parseUri("https://twitter.com/i/api")
   activate* = $(api / "1.1/guest/activate.json")
 
   photoRail* = api / "1.1/statuses/media_timeline.json"
@@ -24,6 +27,8 @@ const
   graphListBySlug* = graphql / "-kmqNvm5Y-cVrfvBy6docg/ListBySlug"
   graphListMembers* = graphql / "P4NpVZDqUD_7MEM84L-8nw/ListMembers"
   graphListTweets* = graphql / "BbGLL1ZfMibdFNWlk7a0Pw/ListTimeline"
+
+  browserGraphTweetResultByRestId* = browserApi / "/graphql/DJS3BdhUhcaEpZ7B7irJDg/TweetResultByRestId"
 
   timelineParams* = {
     "include_can_media_tag": "1",
@@ -91,9 +96,16 @@ const
   $2
   "includeHasBirdwatchNotes": false,
   "includePromotedContent": false,
-  "withBirdwatchNotes": false,
+  "withBirdwatchNotes": true,
   "withVoice": false,
   "withV2Timeline": true
+}""".replace(" ", "").replace("\n", "")
+
+  browserApiTweetVariables* = """{
+  "tweetId": "$1",
+  "includePromotedContent": false,
+  "withCommunity": false,
+  "withVoice": false
 }""".replace(" ", "").replace("\n", "")
 
 #   oldUserTweetsVariables* = """{

--- a/src/sass/tweet/_base.scss
+++ b/src/sass/tweet/_base.scss
@@ -7,6 +7,7 @@
 @import 'card';
 @import 'poll';
 @import 'quote';
+@import 'community-note';
 
 .tweet-body {
     flex: 1;

--- a/src/sass/tweet/community-note.scss
+++ b/src/sass/tweet/community-note.scss
@@ -1,0 +1,59 @@
+@import '_variables';
+@import '_mixins';
+
+.community-note {
+    margin: 5px 0;
+    pointer-events: all;
+    max-height: unset;
+}
+
+.community-note-container {
+    border-radius: 10px;
+    border-width: 1px;
+    border-style: solid;
+    border-color: var(--dark_grey);
+    background-color: var(--bg_elements);
+    overflow: hidden;
+    color: inherit;
+    display: flex;
+    flex-direction: row;
+    text-decoration: none !important;
+
+    &:hover {
+        border-color: var(--grey);
+    }
+
+    .attachments {
+        margin: 0;
+        border-radius: 0;
+    }
+}
+
+.community-note-content {
+    padding: 0.5em;
+}
+
+.community-note-title {
+    white-space: unset;
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
+.community-note-destination {
+    color: var(--grey);
+    display: block;
+}
+
+.community-note-content-container {
+    color: unset;
+    overflow: auto;
+    &:hover {
+        text-decoration: none;
+    }
+}
+
+.large {
+    .community-note-container {
+        display: block;
+    }
+}

--- a/src/tokens.nim
+++ b/src/tokens.nim
@@ -55,7 +55,7 @@ proc getPoolJson*(): JsonNode =
         maxReqs =
           case api
           of Api.search: 50
-          of Api.tweetDetail: 150
+          of Api.tweetDetail, Api.tweetResultByRestId: 150
           of Api.photoRail: 180
           of Api.userTweets, Api.userTweetsAndReplies, Api.userMedia,
              Api.userRestId, Api.userScreenName,
@@ -149,4 +149,5 @@ proc initAccountPool*(cfg: Config; accounts: JsonNode) =
       id: account{"user", "id_str"}.getStr,
       oauthToken: account{"oauth_token"}.getStr,
       oauthSecret: account{"oauth_token_secret"}.getStr,
+      guestToken: account{"guest_token"}.getStr,
     )

--- a/src/types.nim
+++ b/src/types.nim
@@ -17,6 +17,7 @@ type
   Api* {.pure.} = enum
     tweetDetail
     tweetResult
+    tweetResultByRestId
     photoRail
     search
     userSearch
@@ -40,6 +41,7 @@ type
     id*: string
     oauthToken*: string
     oauthSecret*: string
+    guestToken*: string
     pending*: int
     apis*: Table[Api, RateLimit]
 
@@ -206,8 +208,15 @@ type
     gif*: Option[Gif]
     video*: Option[Video]
     photos*: seq[string]
+    communityNote*: Option[CommunityNote]
 
   Tweets* = seq[Tweet]
+
+  CommunityNote* = object
+    title*: string
+    subtitle*: string
+    footer*: string
+    url*: string
 
   Result*[T] = object
     content*: seq[T]

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -203,6 +203,16 @@ proc renderAttribution(user: User; prefs: Prefs): VNode =
     if user.verified:
       icon "ok", class="verified-icon", title="Verified account"
 
+proc renderCommunityNote*(note: CommunityNote): VNode =
+  buildHtml(tdiv(class=("community-note large"))):
+    tdiv(class="community-note-container"):
+      tdiv(class="community-note-content-container"):
+        buildHtml(tdiv(class="community-note-content")):
+          a(href=note.url, rel="noreferrer"): h2(class="community-note-title"):verbatim note.title
+          br()
+          verbatim note.subtitle.replace("\n", "<br>")
+          span(class="community-note-destination"): verbatim note.footer
+
 proc renderMediaTags(tags: seq[User]): VNode =
   buildHtml(tdiv(class="media-tag-block")):
     icon "user"
@@ -320,6 +330,9 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
 
       if tweet.attribution.isSome:
         renderAttribution(tweet.attribution.get(), prefs)
+
+      if tweet.communityNote.isSome:
+        renderCommunityNote(tweet.communityNote.get())
 
       if tweet.card.isSome and tweet.card.get().kind != hidden:
         renderCard(tweet.card.get(), prefs, path)


### PR DESCRIPTION
# Demo

I tested this with tweet http://localhost:8080/elonmusk/status/1692558493255942213#m (with reply http://localhost:8080/teslaownersSV/status/1692597508109684813#m, which still shows the Community Note on the parent tweet in the conversation).

With this pull request:


| Main Tweet                            | Reply                        |
| ----------------------------------- | ----------------------------------- |
| ![nitter_community_note_main](https://github.com/zedeus/nitter/assets/1408859/63f1f9e2-16bf-4d62-8e97-b1d42c94a7ab) | ![nitter_community_note_reply](https://github.com/zedeus/nitter/assets/1408859/e515e655-aef2-4084-9fe3-464544caa35e) |



On Twitter.com:

| Main Tweet                            | Reply                        |
| ----------------------------------- | ----------------------------------- |
|![twitter_community_note_main](https://github.com/zedeus/nitter/assets/1408859/f1cd2556-3e51-4356-bd19-449d283a4f83) |![twitter_community_note_reply](https://github.com/zedeus/nitter/assets/1408859/5d5b8bba-7117-43ad-8e4b-323030761ca8) |

# Retrieving the Community Note

Unfortunately, none of the (undocumented) https://api.twitter.com endpoints used by Nitter seem to include Community Notes contents. However, when setting `withBirdwatchNotes: true`, the `graphTweet` (https://api.twitter.com/graphql/q94uRCEn65LZThakYcPT6g/TweetDetail) API includes a `has_birdwatch_notes` field, which is `true` when a Community Note is present on a tweet. This works both for 'main' selected tweets, and for other tweets in the same conversation.

When viewing a tweet while not signed in on twitter.com, the browser makes a call to https://twitter.com/i/api/graphql/DJS3BdhUhcaEpZ7B7irJDg/TweetResultByRestId . This endpoint actually contains Community Notes for the given tweet (if they exist), under a "birdwatch_pivot" key:

```json
"birdwatch_pivot": {
    "destinationUrl": "https://twitter.com/i/birdwatch/n/1692711122338533397",
    "footer": {
        "text": "Context is written by people who use X, and appears when rated helpful by others.  Find out more.",
        "entities": [
            {
                "fromIndex": 83,
                "toIndex": 96,
                "ref": {
                    "type": "TimelineUrl",
                    "url": "https://twitter.com/i/flow/join-birdwatch",
                    "urlType": "ExternalUrl"
                }
            }
        ]
    },
    "note": {
        "rest_id": "1692711122338533397"
    },
    "subtitle": {
        "text": "Blocking is a basic safety feature that allows basic protection for victims of abuse and stalking. Removing this feature would compromise the safety of many people on social media.\nthehotline.org/resources/stal…",
        "entities": [
            {
                "fromIndex": 181,
                "toIndex": 211,
                "ref": {
                    "type": "TimelineUrl",
                    "url": "https://t.co/0DtCJWEbkG",
                    "urlType": "ExternalUrl"
                }
            }
        ]
    },
    "title": "Readers added context they thought people might want to know",
    "shorttitle": "Readers added context",
    "iconType": "BirdwatchV1Icon"
}
```

However, this endpoint doesn't work with normal OAuth tokens (probably because it's a twitter.com endpoint instead of api.twitter.com). Instead, it uses a `Bearer` token with a hardcoded value, and passes in a "guest token" in an `x-guest-token` header. I grabbed this token directly from the Network dev tool in my browser, but it should also be possible to get it from one of the account-creation scripts floating around on the issue tracker.

Passing in these values, we get a response containing the above JSON object (along with other tweet data that we don't need), which is everything required to render a Community Note

# Implementation

* Each object in `guest_accounts.json` now requires a `guest_token` field (alongside the `oauth_token` and `oauth_token_secret`). This guest token will be passed in as the `x-guest-token` header only when retrieving a Community Note
* When we parse a tweet in `parseGraphTweet`, we check if `has_birdwatch_notes` is `true`. If it is, we then invoke the `TweetDetail` API described above in order to get the Community Note. Since the overwhelming majority of tweets do not have a Community Note, we should call `TweetDetail` fairly infrequently (unless Nitter users like to view tweets with Community Notes on them).
* Before rendering the Community Note, we need to process any entities in it. So far, I've only seen one kind - a link replacement. This is used to make 'Find out more' into a link, and whenever links are embedded into the actual text of the Community Note. The format is similar to other entities, so I was able to reuse some of the code.
* The note is rendered using styles from a new `community-note.scss` file. I'm not a web designer, so I just copy-pasted `card.scss`, removed the ellipses logic, and renamed/removed classes. The result isn't perfect, but it includes all of the elements of a Community Note that display on twitter.com (the link to the note feedback pages, any external links, and the 'Find out more' in the footer).

# Other notes

I ended up making the request to the `TweetDetail` from within `parseTweet`, which requires making lots of `parse` functions async. This doesn't seem great, but the only alternatives I came up with seemed worse:
* We could have the initial parsing just mark tweets with notes (by looking at "has_birdwatch_notes"), and do a second pass to actually fetch them. Unfortunately, there are lots of calls to parseGraphTweet, all of which would need an extra call afterwards.
* We could store a `Future` directly, and only `await` it later from some already `async` function. Unfortunately, this breaks the `flatty` serialization in `redis_cache`, since a `Future` can't be serialized. I didn't see a clear way to make this work with `flatty`.

I didn't include the Community Notes icon - it's an inline SVG on Twitter.com, and I felt somewhat nervous about copyright issues.

This is my first time using Nim, so please let me know if any of this could be done in a more idiomatic way.