### PR TITLE
add rel=me support

### DIFF
--- a/src/views/profile.nim
+++ b/src/views/profile.nim
@@ -50,7 +50,7 @@ proc renderUserCard*(user: User; prefs: Prefs): VNode =
           span:
             let url = replaceUrls(user.website, prefs)
             icon "link"
-            a(href=url): text url.shortLink
+            a(rel="me", href=url): text url.shortLink
 
       tdiv(class="profile-joindate"):
         span(title=getJoinDateFull(user)):


### PR DESCRIPTION
This is to support link verification in Mastodon.

Mastodon does not have any equivalent to Twitter's blue-tick, so if you
want to decorate your profile with some sense of authenticity, you can
verify your profile to be associated with a particular URL: https://docs.joinmastodon.org/user/profile/#verification

GitHub gained native support for this sort of verification sometime
between last November and now, and so when you have a bidirectional link
between your GitHub profile and Mastodon profile, the link to GitHub
will be green.

However, Twitter does not support rel=me, and is unlikely to.

With this change, one can link their profile in their Mastodon bio using
`nitter.net/username`, and for as long as their mastodon profile is linked
back in their Twitter's "URL" field, it will be verified.

There have been similar attempts with "trusted" proxy URLs in the past,
i.e. Twitter profile mirrors that are set up for the sole purpose of
supporting rel=me verification. Those proxies are however unknown to
most people, and the entire domain-based verification system kind of
breaks down if nobody knows whether the domain can be trusted.

People know `nitter.net`, however, and trust what is written on there to
match what is written on twitter.com[^1]

Who knows whether the same is true for the unofficial Nitter instances,
but I think one can ignore them for this purpose. Of course I can deploy
this fork today on nitter.woodland.cafe and then verify
`@untitaker@woodland.cafe` against `nitter.woodland.cafe/untitaker`, but
that's kind of pointless.

At the moment this is probably pointless to roll out though, because
`nitter.net` blocks a lot of datacenter ASNs due to intense scraping
efforts. So it would likely block all Mastodon servers.

----


[^1]: Whether it is really *known* may be debatable, but of all Twitter
    mirrors/proxies, I think nitter.net and maybe fxtwitter.com have the
    highest domain reputation and the best chance at making this kind of
    verification system work for Twitter.
