### PR TITLE
Bump nim version minimal requirement + update dockerfile arm

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,7 +1,7 @@
-FROM alpine:3.17 as nim
+FROM alpine:3.18 as nim
 LABEL maintainer="setenforce@protonmail.com"
 
-RUN apk --no-cache add gcc git libc-dev libsass-dev "nim=1.6.8-r0" nimble pcre
+RUN apk --no-cache add gcc git libc-dev libsass-dev "nim=1.6.14-r0" nimble pcre
 
 WORKDIR /src/nitter
 
@@ -13,7 +13,7 @@ RUN nimble build -d:danger -d:lto -d:strip \
     && nimble scss \
     && nimble md
 
-FROM alpine:3.17
+FROM alpine:3.18
 WORKDIR /src/
 RUN apk --no-cache add ca-certificates pcre openssl1.1-compat
 COPY --from=nim /src/nitter/nitter ./

--- a/nitter.nimble
+++ b/nitter.nimble
@@ -10,7 +10,7 @@ bin           = @["nitter"]
 
 # Dependencies
 
-requires "nim >= 1.4.8"
+requires "nim >= 1.6.10"
 requires "jester#baca3f"
 requires "karax#5cf360c"
 requires "sass#7dfdd03"


### PR DESCRIPTION
From the discussion: https://github.com/zedeus/nitter/pull/985/files#r1377420589

This bumps the minimal requirement for nim version to `1.6.10` and also update the dockerfile for ARM to nim `1.6.14`.