### PR TITLE
Add functionality to fetch guest accounts on demand

### DIFF
--- a/nitter.example.conf
+++ b/nitter.example.conf
@@ -33,6 +33,12 @@ tokenCount = 10
 # always at least `tokenCount` usable tokens. only increase this if you receive
 # major bursts all the time and don't have a rate limiting setup via e.g. nginx
 
+# Instead of guest_accounts.json, fetch guest accounts from an external URL.
+# Nitter will re-fetch accounts if it runs out of valid ones.
+guestAccountsUrl = ""    # https://example.com/download
+guestAccountsHost = ""   # defaults to nitter's hostname
+guestAccountsKey = ""    # a random string that will be used as a secret to authenticate against the URL
+
 # Change default preferences here, see src/prefs_impl.nim for a complete list
 [Preferences]
 theme = "Nitter"

--- a/nitter.example.conf
+++ b/nitter.example.conf
@@ -26,18 +26,14 @@ enableRSS = true  # set this to false to disable RSS feeds
 enableDebug = false  # enable request logs and debug endpoints (/.accounts)
 proxy = ""  # http/https url, SOCKS proxies are not supported
 proxyAuth = ""
-tokenCount = 10
-# minimum amount of usable tokens. tokens are used to authorize API requests,
-# but they expire after ~1 hour, and have a limit of 500 requests per endpoint.
-# the limits reset every 15 minutes, and the pool is filled up so there's
-# always at least `tokenCount` usable tokens. only increase this if you receive
-# major bursts all the time and don't have a rate limiting setup via e.g. nginx
 
 # Instead of guest_accounts.json, fetch guest accounts from an external URL.
 # Nitter will re-fetch accounts if it runs out of valid ones.
-guestAccountsUrl = ""    # https://example.com/download
-guestAccountsHost = ""   # defaults to nitter's hostname
-guestAccountsKey = ""    # a random string that will be used as a secret to authenticate against the URL
+[GuestAccounts]
+usePool = false  # enable fetching accounts from external pool.
+poolUrl = ""     # https://example.com/download
+poolId = ""      # defaults to nitter's hostname
+poolAuth = ""    # random secret string for authentication
 
 # Change default preferences here, see src/prefs_impl.nim for a complete list
 [Preferences]

--- a/src/auth.nim
+++ b/src/auth.nim
@@ -221,14 +221,14 @@ proc updateAccountPool*(cfg: Config) {.async.} =
       let client = newAsyncHttpClient()
 
       try:
-          let resp = await client.get($(cfg.guestAccountsPoolUrl ? {"id": cfg.guestAccountsPoolId, "auth": cfg.guestAccountsPoolAuth}))
-          let guestAccounts = await resp.body
+        let resp = await client.get($(cfg.guestAccountsPoolUrl ? {"id": cfg.guestAccountsPoolId, "auth": cfg.guestAccountsPoolAuth}))
+        let guestAccounts = await resp.body
 
-          log "status code from service: ", resp.status
+        log "status code from service: ", resp.status
 
-          for line in guestAccounts.splitLines:
-            if line != "":
-              accountPool.add parseGuestAccount(line)
+        for line in guestAccounts.splitLines:
+          if line != "":
+            accountPool.add parseGuestAccount(line)
 
       except Exception as e:
         log "failed to fetch from accounts service: ", e.msg

--- a/src/auth.nim
+++ b/src/auth.nim
@@ -218,7 +218,7 @@ proc updateAccountPool*(cfg: Config) {.async.} =
     if accountPool.len == 0:
       log "fetching more accounts from service"
 
-      let client = newAsyncHttpClient()
+      let client = newAsyncHttpClient("nitter-accounts")
 
       try:
         let resp = await client.get($(cfg.guestAccountsPoolUrl ? {"id": cfg.guestAccountsPoolId, "auth": cfg.guestAccountsPoolAuth}))

--- a/src/auth.nim
+++ b/src/auth.nim
@@ -216,7 +216,7 @@ proc updateAccountPool*(cfg: Config) {.async.} =
 
       log "fetching more accounts from service"
       pool.use(newHttpHeaders()):
-        let resp = await c.get("$1?host=$2&key=$3" % [cfg.guestAccountsPoolUrl, cfg.guestAccountsPoolId, cfg.guestAccountsPoolAuth])
+        let resp = await c.get("$1?id=$2&auth=$3" % [cfg.guestAccountsPoolUrl, cfg.guestAccountsPoolId, cfg.guestAccountsPoolAuth])
         let guestAccounts = await resp.body
 
         log "status code from service: ", resp.status

--- a/src/config.nim
+++ b/src/config.nim
@@ -36,14 +36,16 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
     # Config
     hmacKey: cfg.get("Config", "hmacKey", "secretkey"),
     base64Media: cfg.get("Config", "base64Media", false),
-    minTokens: cfg.get("Config", "tokenCount", 10),
     enableRss: cfg.get("Config", "enableRSS", true),
     enableDebug: cfg.get("Config", "enableDebug", false),
     proxy: cfg.get("Config", "proxy", ""),
     proxyAuth: cfg.get("Config", "proxyAuth", ""),
-    guestAccountsUrl: cfg.get("Config", "guestAccountsUrl", ""),
-    guestAccountsKey: cfg.get("Config", "guestAccountsKey", ""),
-    guestAccountsHost: cfg.get("Config", "guestAccountsHost", cfg.get("Server", "hostname", ""))
+
+    # GuestAccounts
+    guestAccountsUsePool: cfg.get("GuestAccounts", "usePool", false),
+    guestAccountsPoolUrl: cfg.get("GuestAccounts", "poolUrl", ""),
+    guestAccountsPoolAuth: cfg.get("GuestAccounts", "poolAuth", ""),
+    guestAccountsPoolId: cfg.get("GuestAccounts", "poolId", cfg.get("Server", "hostname", ""))
   )
 
   return (conf, cfg)

--- a/src/config.nim
+++ b/src/config.nim
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
-import parsecfg except Config
-import types, strutils
+import std/parsecfg except Config
 import std/uri
+import types, strutils
 
 proc get*[T](config: parseCfg.Config; section, key: string; default: T): T =
   let val = config.getSectionValue(section, key)

--- a/src/config.nim
+++ b/src/config.nim
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 import parsecfg except Config
 import types, strutils
+import std/uri
 
 proc get*[T](config: parseCfg.Config; section, key: string; default: T): T =
   let val = config.getSectionValue(section, key)
@@ -43,7 +44,7 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
 
     # GuestAccounts
     guestAccountsUsePool: cfg.get("GuestAccounts", "usePool", false),
-    guestAccountsPoolUrl: cfg.get("GuestAccounts", "poolUrl", ""),
+    guestAccountsPoolUrl: parseUri(cfg.get("GuestAccounts", "poolUrl", "")),
     guestAccountsPoolAuth: cfg.get("GuestAccounts", "poolAuth", ""),
     guestAccountsPoolId: cfg.get("GuestAccounts", "poolId", cfg.get("Server", "hostname", ""))
   )

--- a/src/config.nim
+++ b/src/config.nim
@@ -40,7 +40,10 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
     enableRss: cfg.get("Config", "enableRSS", true),
     enableDebug: cfg.get("Config", "enableDebug", false),
     proxy: cfg.get("Config", "proxy", ""),
-    proxyAuth: cfg.get("Config", "proxyAuth", "")
+    proxyAuth: cfg.get("Config", "proxyAuth", ""),
+    guestAccountsUrl: cfg.get("Config", "guestAccountsUrl", ""),
+    guestAccountsKey: cfg.get("Config", "guestAccountsKey", ""),
+    guestAccountsHost: cfg.get("Config", "guestAccountsHost", cfg.get("Server", "hostname", ""))
   )
 
   return (conf, cfg)

--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -22,6 +22,7 @@ let
   accountsPath = getEnv("NITTER_ACCOUNTS_FILE", "./guest_accounts.json")
 
 initAccountPool(cfg, accountsPath)
+asyncCheck updateAccountPool(cfg)
 
 if not cfg.enableDebug:
   # Silence Jester's query warning

--- a/src/nitter.nim
+++ b/src/nitter.nim
@@ -10,7 +10,7 @@ import types, config, prefs, formatters, redis_cache, http_pool, auth
 import views/[general, about]
 import routes/[
   preferences, timeline, status, media, search, rss, list, debug,
-  unsupported, embed, resolver, router_utils]
+  unsupported, embed, resolver, router_utils, auth]
 
 const instancesUrl = "https://github.com/zedeus/nitter/wiki/Instances"
 const issuesUrl = "https://github.com/zedeus/nitter/issues"
@@ -54,6 +54,7 @@ createMediaRouter(cfg)
 createEmbedRouter(cfg)
 createRssRouter(cfg)
 createDebugRouter(cfg)
+createAuthRouter(cfg)
 
 settings:
   port = Port(cfg.port)
@@ -108,3 +109,4 @@ routes:
   extend embed, ""
   extend debug, ""
   extend unsupported, ""
+  extend auth, ""

--- a/src/routes/auth.nim
+++ b/src/routes/auth.nim
@@ -7,6 +7,6 @@ import ".."/[types, auth]
 
 proc createAuthRouter*(cfg: Config) =
   router auth:
-    get "/.well-known/nitter-auth-sha256":
-      cond cfg.guestAccountsUrl != ""
+    get "/.well-known/nitter-request-auth":
+      cond cfg.guestAccountsUsePool
       resp Http200, {"content-type": "text/plain"}, getAuthHash(cfg)

--- a/src/routes/auth.nim
+++ b/src/routes/auth.nim
@@ -7,6 +7,6 @@ import ".."/[types, auth]
 
 proc createAuthRouter*(cfg: Config) =
   router auth:
-    get "/.well-known/nitter-request-auth":
+    get "/.well-known/nitter-auth":
       cond cfg.guestAccountsUsePool
       resp Http200, {"content-type": "text/plain"}, getAuthHash(cfg)

--- a/src/routes/auth.nim
+++ b/src/routes/auth.nim
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: AGPL-3.0-only
+
+import jester
+
+import router_utils
+import ".."/[types, auth]
+
+proc createAuthRouter*(cfg: Config) =
+  router auth:
+    get "/.well-known/nitter-auth-sha256":
+      cond cfg.guestAccountsUrl != ""
+      resp Http200, {"content-type": "text/plain"}, getAuthHash(cfg)

--- a/src/types.nim
+++ b/src/types.nim
@@ -254,6 +254,9 @@ type
     title*: string
     hostname*: string
     staticDir*: string
+    guestAccountsUrl*: string
+    guestAccountsKey*: string
+    guestAccountsHost*: string
 
     hmacKey*: string
     base64Media*: bool

--- a/src/types.nim
+++ b/src/types.nim
@@ -254,17 +254,18 @@ type
     title*: string
     hostname*: string
     staticDir*: string
-    guestAccountsUrl*: string
-    guestAccountsKey*: string
-    guestAccountsHost*: string
 
     hmacKey*: string
     base64Media*: bool
-    minTokens*: int
     enableRss*: bool
     enableDebug*: bool
     proxy*: string
     proxyAuth*: string
+
+    guestAccountsUsePool*: bool
+    guestAccountsPoolUrl*: string
+    guestAccountsPoolId*: string
+    guestAccountsPoolAuth*: string
 
     rssCacheTime*: int
     listCacheTime*: int

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-only
-import times, sequtils, options, tables
+import std/[times, sequtils, options, tables, uri]
 import prefs_impl
-import std/uri
 
 genPrefsType()
 

--- a/src/types.nim
+++ b/src/types.nim
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-only
 import times, sequtils, options, tables
 import prefs_impl
+import std/uri
 
 genPrefsType()
 
@@ -263,7 +264,7 @@ type
     proxyAuth*: string
 
     guestAccountsUsePool*: bool
-    guestAccountsPoolUrl*: string
+    guestAccountsPoolUrl*: Uri
     guestAccountsPoolId*: string
     guestAccountsPoolAuth*: string
 


### PR DESCRIPTION
Add a basic way to automatically fetch guest accounts from an external URL if the internal stash is empty.

for example:

```
guestAccountsUrl = "https://twitterminator.x86-64-unknown-linux-gnu.zip/download"
guestAccountsKey = "<random string>"
```

If those settings are configured, guest_accounts.json does not need to be present.

this serves the hashed Key under `/.well-known/nitter-auth-sha256`, while twitterminator expects it under `/.twitterminator.txt`. If this approach is accepted I'll update twitterminator to look for the new path too.