### PR TITLE
Add in nonce support for Content-Security-Policy

### DIFF
--- a/nitter.example.conf
+++ b/nitter.example.conf
@@ -21,6 +21,7 @@ redisMaxConnections = 30
 
 [Config]
 hmacKey = "secretkey"  # random key for cryptographic signing of video urls
+nonceString = "secretstring" # random string for the Content-Security-Policy header with script-src
 base64Media = false  # use base64 encoding for proxied media urls
 enableRSS = true  # set this to false to disable RSS feeds
 enableDebug = false  # enable request logs and debug endpoints (/.accounts)

--- a/public/js/hlsPlayback.js
+++ b/public/js/hlsPlayback.js
@@ -1,30 +1,40 @@
 // @license http://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
 // SPDX-License-Identifier: AGPL-3.0-only
-const video_overlay = document.getElementsByClassName("video-overlay");
+function playVideo() {
+        const video_overlay = document.getElementsByClassName("video-overlay");
+    
+        for (var i = 0 ; i < video_overlay.length; i++) {
+        video_overlay[i].addEventListener('click', function () {
 
-for (var i = 0 ; i < video_overlay.length; i++) {
-   video_overlay[i].addEventListener('click', function () {
+            const video = this.parentElement.querySelector('video');
+            const url = video.getAttribute("data-url");
+            video.setAttribute("controls", "");
+            this.style.display = "none";
 
-        const video = this.parentElement.querySelector('video');
-        const url = video.getAttribute("data-url");
-        video.setAttribute("controls", "");
-        this.style.display = "none";
-
-        if (Hls.isSupported()) {
-            var hls = new Hls({autoStartLoad: false});
-            hls.loadSource(url);
-            hls.attachMedia(video);
-            hls.on(Hls.Events.MANIFEST_PARSED, function () {
-                hls.loadLevel = hls.levels.length - 1;
-                hls.startLoad();
-                video.play();
-            });
-        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
-            video.src = url;
-            video.addEventListener('canplay', function() {
-                video.play();
-            });
-        }
-    });
+            if (Hls.isSupported()) {
+                var hls = new Hls({autoStartLoad: false});
+                hls.loadSource(url);
+                hls.attachMedia(video);
+                hls.on(Hls.Events.MANIFEST_PARSED, function () {
+                    hls.loadLevel = hls.levels.length - 1;
+                    hls.startLoad();
+                    video.play();
+                });
+            } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+                video.src = url;
+                video.addEventListener('canplay', function() {
+                    video.play();
+                });
+            }
+        });
+    }
 }
+
+var observer = new MutationObserver(function () {
+    playVideo()
+});
+
+playVideo()
+
+observer.observe(document.body, {childList: true, subtree: true});
 // @license-end

--- a/public/js/hlsPlayback.js
+++ b/public/js/hlsPlayback.js
@@ -1,9 +1,9 @@
 // @license http://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
 // SPDX-License-Identifier: AGPL-3.0-only
 function playVideo() {
-        const video_overlay = document.getElementsByClassName("video-overlay");
+    const video_overlay = document.getElementsByClassName("video-overlay");
     
-        for (var i = 0 ; i < video_overlay.length; i++) {
+    for (var i = 0 ; i < video_overlay.length; i++) {
         video_overlay[i].addEventListener('click', function () {
 
             const video = this.parentElement.querySelector('video');

--- a/public/js/hlsPlayback.js
+++ b/public/js/hlsPlayback.js
@@ -1,25 +1,30 @@
 // @license http://www.gnu.org/licenses/agpl-3.0.html AGPL-3.0
 // SPDX-License-Identifier: AGPL-3.0-only
-function playVideo(overlay) {
-    const video = overlay.parentElement.querySelector('video');
-    const url = video.getAttribute("data-url");
-    video.setAttribute("controls", "");
-    overlay.style.display = "none";
+const video_overlay = document.getElementsByClassName("video-overlay");
 
-    if (Hls.isSupported()) {
-        var hls = new Hls({autoStartLoad: false});
-        hls.loadSource(url);
-        hls.attachMedia(video);
-        hls.on(Hls.Events.MANIFEST_PARSED, function () {
-            hls.loadLevel = hls.levels.length - 1;
-            hls.startLoad();
-            video.play();
-        });
-    } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
-        video.src = url;
-        video.addEventListener('canplay', function() {
-            video.play();
-        });
-    }
+for (var i = 0 ; i < video_overlay.length; i++) {
+   video_overlay[i].addEventListener('click', function () {
+
+        const video = this.parentElement.querySelector('video');
+        const url = video.getAttribute("data-url");
+        video.setAttribute("controls", "");
+        this.style.display = "none";
+
+        if (Hls.isSupported()) {
+            var hls = new Hls({autoStartLoad: false});
+            hls.loadSource(url);
+            hls.attachMedia(video);
+            hls.on(Hls.Events.MANIFEST_PARSED, function () {
+                hls.loadLevel = hls.levels.length - 1;
+                hls.startLoad();
+                video.play();
+            });
+        } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+            video.src = url;
+            video.addEventListener('canplay', function() {
+                video.play();
+            });
+        }
+    });
 }
 // @license-end

--- a/src/config.nim
+++ b/src/config.nim
@@ -35,6 +35,7 @@ proc getConfig*(path: string): (Config, parseCfg.Config) =
 
     # Config
     hmacKey: cfg.get("Config", "hmacKey", "secretkey"),
+    nonceString: cfg.get("Config", "nonceString", "secretstring"),
     base64Media: cfg.get("Config", "base64Media", false),
     minTokens: cfg.get("Config", "tokenCount", 10),
     enableRss: cfg.get("Config", "enableRSS", true),

--- a/src/types.nim
+++ b/src/types.nim
@@ -256,6 +256,7 @@ type
     staticDir*: string
 
     hmacKey*: string
+    nonceString*: string
     base64Media*: bool
     minTokens*: int
     enableRss*: bool

--- a/src/views/general.nim
+++ b/src/views/general.nim
@@ -73,11 +73,11 @@ proc renderHead*(prefs: Prefs; cfg: Config; req: Request; titleText=""; desc="";
       link(rel="alternate", type="application/rss+xml", href=rss, title="RSS feed")
 
     if prefs.hlsPlayback:
-      script(src="/js/hls.light.min.js", `defer`="")
-      script(src="/js/hlsPlayback.js", `defer`="")
+      script(nonce=cfg.nonceString, src="/js/hls.light.min.js", `defer`="")
+      script(nonce=cfg.nonceString, src="/js/hlsPlayback.js", `defer`="")
 
     if prefs.infiniteScroll:
-      script(src="/js/infiniteScroll.js", `defer`="")
+      script(nonce=cfg.nonceString, src="/js/infiniteScroll.js", `defer`="")
 
     title:
       if titleText.len > 0:

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -109,7 +109,7 @@ proc renderVideo*(video: Video; prefs: Prefs; path: string): VNode =
               source(src=source, `type`="video/mp4")
           of m3u8, vmap:
             video(poster=thumb, data-url=source, data-autoload="false", muted=prefs.muteVideos)
-            verbatim "<div class=\"video-overlay\" onclick=\"playVideo(this)\">"
+            verbatim "<div class=\"video-overlay\">"
             tdiv(class="overlay-circle"): span(class="overlay-triangle")
             verbatim "</div>"
       if container.len > 0:


### PR DESCRIPTION
This adds in the ability to specify a nonce value for the scripts to use with the Content-Security-Policy header.
You can specify the nonce via the configuration file. Not replacing the default string has no impact as long as you keep `script-src 'self' 'unsafe-inline';` in the CSP header

For example if you set nonceString to "mysupersecretnoncevalue" in the config file the NGINX setup would look something like this:
```
add_header Content-Security-Policy "default-src 'none'; script-src 'strict-dynamic' 'nonce-$request_id' 'self'; ...the rest of the Content-Security-Policy header
sub_filter_once off;
sub_filter_types *;
sub_filter mysupersecretnoncevalue $request_id;
```

It's currently set up on [my instance](https://nitter.catsarch.com). The reasing for the script-src options is that 'strict-dynamic' and 'nonce-$request_id' override 'self' in other browsers and force that only scripts who's nonce value has been replaced will be executed. Older browsers that don't understand nonces will fall back to 'self' and at least still function despite the lessened security. These values can be checked at https://csp-evaluator.withgoogle.com/