### PR TITLE
chore: Revert back to nim 2.0 for alpine ARM64

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,4 +1,4 @@
-FROM alpine:3.21.2 as nim
+FROM alpine:3.20.6 as nim
 LABEL maintainer="setenforce@protonmail.com"
 
 RUN apk --no-cache add libsass-dev pcre gcc git libc-dev nim nimble
@@ -13,7 +13,7 @@ RUN nimble build -d:danger -d:lto -d:strip --mm:refc \
     && nimble scss \
     && nimble md
 
-FROM alpine:3.21.2
+FROM alpine:3.20.6
 WORKDIR /src/
 RUN apk --no-cache add pcre ca-certificates openssl
 COPY --from=nim /src/nitter/nitter ./


### PR DESCRIPTION
Nim 2.2.0 causes some segfault issues.