### PR TITLE
Update Docker Compose configuration file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
 
   nitter:


### PR DESCRIPTION
According to the official documentation, Docker Compose files are now supposed to be named `compose.yml`:
https://docs.docker.com/compose/intro/compose-application-model/

The `version:` line has also been deprecated:
https://docs.docker.com/reference/compose-file/version-and-name/#version-top-level-element-obsolete