### PR TITLE
fix: use proxy configuration for transaction ID pair fetching

### DIFF
--- a/src/http_pool.nim
+++ b/src/http_pool.nim
@@ -18,6 +18,9 @@ proc setHttpProxy*(url: string; auth: string) =
   else:
     proxy = nil
 
+proc getHttpProxy*(): Proxy =
+  return proxy
+
 proc release*(pool: HttpPool; client: AsyncHttpClient; badClient=false) =
   if pool.conns.len >= maxConns or badClient:
     try: client.close()

--- a/src/tid.nim
+++ b/src/tid.nim
@@ -1,6 +1,7 @@
 import std/[asyncdispatch, base64, httpclient, random, strutils, sequtils, times]
 import nimcrypto
 import experimental/parser/tid
+import http_pool
 
 randomize()
 
@@ -18,7 +19,7 @@ proc getPair(): Future[TidPair] {.async.} =
   if cachedPairs.len == 0 or int(epochTime()) - lastCached > ttlSec:
     lastCached = int(epochTime())
 
-    let client = newAsyncHttpClient()
+    let client = newAsyncHttpClient(proxy=getHttpProxy())
     defer: client.close()
 
     let resp = await client.get(pairsUrl)


### PR DESCRIPTION
Add getHttpProxy() function to http_pool module to retrieve the configured proxy. Update tid.nim to use the proxy when fetching transaction ID pairs from the remote repository, ensuring proxy settings are respected for all HTTP requests.