### PR TITLE
Fix the checkmark position

### DIFF
--- a/src/views/profile.nim
+++ b/src/views/profile.nim
@@ -26,6 +26,7 @@ proc renderUserCard*(user: User; prefs: Prefs): VNode =
 
       tdiv(class="profile-card-tabs-name"):
         linkUser(user, class="profile-card-fullname")
+        verifiedIcon(user)
         linkUser(user, class="profile-card-username")
 
     tdiv(class="profile-card-extra"):

--- a/src/views/renderutils.nim
+++ b/src/views/renderutils.nim
@@ -42,7 +42,6 @@ proc linkUser*(user: User, class=""): VNode =
   buildHtml(a(href=href, class=class, title=nameText)):
     text nameText
     if isName:
-      verifiedIcon(user)
       if user.protected:
         text " "
         icon "lock", title="Protected account"

--- a/src/views/timeline.nim
+++ b/src/views/timeline.nim
@@ -66,6 +66,7 @@ proc renderUser(user: User; prefs: Prefs): VNode =
         tdiv(class="tweet-name-row"):
           tdiv(class="fullname-and-username"):
             linkUser(user, class="fullname")
+            verifiedIcon(user)
         linkUser(user, class="username")
 
       tdiv(class="tweet-content media-body", dir="auto"):

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -31,6 +31,7 @@ proc renderHeader(tweet: Tweet; retweet: string; pinned: bool; prefs: Prefs): VN
       tdiv(class="tweet-name-row"):
         tdiv(class="fullname-and-username"):
           linkUser(tweet.user, class="fullname")
+          verifiedIcon(tweet.user)
           linkUser(tweet.user, class="username")
 
         span(class="tweet-date"):
@@ -235,6 +236,7 @@ proc renderQuote(quote: Tweet; prefs: Prefs; path: string): VNode =
       tdiv(class="fullname-and-username"):
         renderMiniAvatar(quote.user, prefs)
         linkUser(quote.user, class="fullname")
+        verifiedIcon(quote.user)
         linkUser(quote.user, class="username")
 
       span(class="tweet-date"):


### PR DESCRIPTION
## Description

If the profile name is too long and has a checkmark, this checkmark gets in the way of other elements on the right. On mobile it's even worse because it widens the page by creating an empty space on the right side to fit the checkmark.

## Reproduction

Open any page with a tweet from a verified author with a long profile name like [this](https://nitter.net/mushoku_eiyu/status/2001283991341871371) or [this](https://nitter.net/futsutsuka_PR/status/2003299652867867082).

## Solution

The fix is trivial and requires moving the verified-icon div element one level up.

I built and run the patched version, which took me way more time than i expected, to make sure everything works correctly. The upper screenshot is taken using nitter.com and the lower is taken using the patched version.
![](https://i.imgur.com/Sz8HqFe.png)