### PR TITLE
Fix OpenSearch response crash

### DIFF
--- a/src/routes/search.nim
+++ b/src/routes/search.nim
@@ -46,6 +46,7 @@ proc createSearchRouter*(cfg: Config) =
       redirect("/search?f=tweets&q=" & encodeUrl("#" & @"hash"))
 
     get "/opensearch":
-      let url = getUrlPrefix(cfg) & "/search?f=tweets&q="
-      resp Http200, {"Content-Type": "application/opensearchdescription+xml"},
-                     generateOpenSearchXML(cfg.title, cfg.hostname, url)
+      let
+        url = getUrlPrefix(cfg) & "/search?f=tweets&q="
+        headers = {"Content-Type": "application/opensearchdescription+xml"}
+      resp Http200, headers, generateOpenSearchXML(cfg.title, cfg.hostname, url)


### PR DESCRIPTION
## Summary

Fixes a crash when serving `/opensearch` by binding the response headers before passing them to `resp`.

The route previously passed an inline header literal directly to `resp`:

```nim
resp Http200, {"Content-Type": "application/opensearchdescription+xml"}, ...
```

With Nim 2.2.0/Jester, requesting `/opensearch` could SIGSEGV while handling that response. Binding the headers to a local first avoids that assignment path while preserving the same response status, content type, and XML body.

## Validation

- Reproduced the crash with a direct request to `/opensearch`.
- A debug build showed the crash at `src/routes/search.nim` inside the `/opensearch` response path, through Nim's generic assignment handling.
- Verified the patched route returns `200 OK` with `application/opensearchdescription+xml` and the expected XML.
