### PR TITLE
Linkify multi-feed and retweet usernames

### DIFF
--- a/src/views/search.nim
+++ b/src/views/search.nim
@@ -126,7 +126,10 @@ proc renderTweetSearch*(results: Timeline; prefs: Prefs; path: string;
   buildHtml(tdiv(class=containerClass)):
     if query.fromUser.len > 1:
       tdiv(class="timeline-header"):
-        text query.fromUser.join(" | ")
+        for index, username in query.fromUser:
+          if index > 0:
+            text " | "
+          a(href=("/" & username)): text username
 
     if query.fromUser.len > 0:
       if query.kind != QueryKind.media or query.view != "gallery":

--- a/src/views/tweet.nim
+++ b/src/views/tweet.nim
@@ -27,7 +27,7 @@ proc renderArticleCard(preview: ArticlePreview; prefs: Prefs): VNode =
           if preview.previewText.len > 0:
             p(class="card-description"): text preview.previewText
 
-proc renderHeader(tweet: Tweet; retweet: string; pinned: bool; prefs: Prefs;
+proc renderHeader(tweet: Tweet; retweet: User; pinned: bool; prefs: Prefs;
                    path = ""): VNode =
   buildHtml(tdiv):
     if pinned:
@@ -36,9 +36,11 @@ proc renderHeader(tweet: Tweet; retweet: string; pinned: bool; prefs: Prefs;
         else: "Pinned Tweet"
       tdiv(class="pinned"):
         span: icon("pin", pinnedLabel)
-    elif retweet.len > 0:
+    elif retweet.username.len > 0:
       tdiv(class="retweet-header"):
-        span: icon("retweet", retweet & " retweeted")
+        span:
+          a(href=("/" & retweet.username)):
+            icon("retweet", retweet.fullname & " retweeted")
 
     tdiv(class="tweet-header"):
       a(class="tweet-avatar", href=("/" & tweet.user.username)):
@@ -396,11 +398,11 @@ proc renderTweet*(tweet: Tweet; prefs: Prefs; path: string; class=""; index=0;
     fullTweet = tweet
     pinned = tweet.pinned
 
-  var retweet: string
+  var retweet: User
   var tweet = fullTweet
   if tweet.retweet.isSome:
     tweet = tweet.retweet.get
-    retweet = fullTweet.user.fullname
+    retweet = fullTweet.user
 
   buildHtml(tdiv(class=("timeline-item " & divClass), data-username=tweet.user.username)):
     if not mainTweet:

--- a/tests/test_linkified_users_1428.nim
+++ b/tests/test_linkified_users_1428.nim
@@ -1,0 +1,30 @@
+import options, strutils, unittest
+import karax/vdom
+
+import ../src/types
+import ../src/views/[search, tweet]
+
+suite "linkified feed users":
+  test "multi-feed header links each username":
+    let timeline = Timeline(query: Query(kind: tweets, fromUser: @["alice", "bob"]))
+
+    let html = $renderTweetSearch(timeline, Prefs(), "")
+
+    check "href=\"/alice\"" in html
+    check "href=\"/bob\"" in html
+
+  test "retweet header links the retweeter":
+    let original = Tweet(
+      available: true,
+      user: User(username: "author", fullname: "Author")
+    )
+    let repost = Tweet(
+      available: true,
+      user: User(username: "booster", fullname: "Booster"),
+      retweet: some(original)
+    )
+
+    let html = $renderTweet(repost, Prefs(), "")
+
+    check "href=\"/booster\"" in html
+    check "Booster retweeted" in html


### PR DESCRIPTION
## Summary

- Link each username in the multi-feed timeline header to its profile.
- Link the retweeter name in retweet headers to the retweeter's profile.
- Add focused rendering tests for both links.

## Verification

- `nim c -r tests/test_linkified_users_1428.nim`
- `docker build --target nim -t nitter-1428-test .`

Fixes #1428
